### PR TITLE
Fixed missing ";"

### DIFF
--- a/configuration/user.js
+++ b/configuration/user.js
@@ -12,5 +12,4 @@ user_pref("browser.tabs.drawInTitlebar", true);
 user_pref("browser.uidensity", 0);
 
 // Enable SVG context-propertes
-user_pref("svg.context-properties.content.enabled", true)
-
+user_pref("svg.context-properties.content.enabled", true);


### PR DESCRIPTION
Fixed a missing ";" in `user.js` that prevented setting `svg.context-properties.content.enabled` to true. Hopefully this fixes #142  