### PR TITLE
Minor tab/headerbar fixes

### DIFF
--- a/theme/colors/dark.css
+++ b/theme/colors/dark.css
@@ -13,8 +13,11 @@
 		--gnome-toolbar-background: #282828;	
 		--gnome-toolbar-color: #ffffff;
 		--gnome-toolbar-border-color: #1b1b1b;
+		--gnome-toolbar-icon-fill: #eeeeec;
+		--gnome-inactive-toolbar-color: #919190;
 		--gnome-inactive-toolbar-background: #353535;	
 		--gnome-inactive-toolbar-border-color: #202020;
+		--gnome-inactive-toolbar-icon-fill: #919190;
 
 		/* Sidebar */
 		--gnome-sidebar-background: #313131;
@@ -93,6 +96,8 @@
 
 		/* Tabs */
 		--gnome-tabbar-tab-color: rgb(141, 144, 145);
+		--gnome-tabbar-tab-background: #282828;
+		--gnome-tabbar-tab-border-color: #242424;
 		--gnome-tabbar-tab-hover-background: #2b2b2b;
 		--gnome-tabbar-tab-hover-border-bottom-color: #1b1b1b;
 		--gnome-tabbar-tab-hover-color: rgb(200, 200, 200);
@@ -103,6 +108,7 @@
 		--gnome-tabbar-tab-active-color: #ffffff;
 		--gnome-tabbar-tab-active-hover-background: #313131;
 		--gnome-inactive-tabbar-tab-color: rgb(141, 144, 145);
+		--gnome-inactive-tabbar-tab-background: #2e2e2e;
 		--gnome-inactive-tabbar-tab-active-background: #353535;
 		--gnome-inactive-tabbar-tab-active-border-bottom-color: #15539e;
 		--gnome-inactive-tabbar-tab-active-color: rgb(141, 144, 145);  

--- a/theme/colors/light.css
+++ b/theme/colors/light.css
@@ -13,8 +13,11 @@
 	--gnome-toolbar-background: #e0ddda;	
 	--gnome-toolbar-color: rgb(46, 52, 54);
 	--gnome-toolbar-border-color: #b6b6b3;
+	--gnome-toolbar-icon-fill: #2e3436;
 	--gnome-inactive-toolbar-background: #f6f5f4;	
-	--gnome-inactive-toolbar-border-color: #c0c0bd;
+	--gnome-inactive-toolbar-color: #d5d0cc;
+	--gnome-inactive-toolbar-border-color: #d5d0cc;
+	--gnome-inactive-toolbar-icon-fill: #929595;
 
 	/* Sidebar */
 	--gnome-sidebar-background: #fbfafa;
@@ -34,7 +37,7 @@
 	--gnome-headerbar-border-color: #bdb7b0;
 	--gnome-headerbar-box-shadow: 0 -1px rgb(217, 217, 217) inset, 0 1px #fff inset;
 	--gnome-inactive-headerbar-background: linear-gradient(#f6f5f4, #f6f5f4);
-	--gnome-inactive-headerbar-border-color: #c0c0bd;
+	--gnome-inactive-headerbar-border-color: #d5d0cc;
 	--gnome-inactive-headerbar-box-shadow: 0 1px #fff inset;
 
 	/* Buttons */
@@ -51,7 +54,7 @@
 	--gnome-button-disabled-border-color: #cdc7c2;
 	--gnome-button-disabled-box-shadow: inset 0 1px rgba(255, 255, 255, 0);
 	--gnome-inactive-button-background: linear-gradient(#f6f5f4, #f6f5f4);
-	--gnome-inactive-button-border-color: #c0c0bd;
+	--gnome-inactive-button-border-color: #d5d0cc;
 	--gnome-inactive-button-box-shadow: 0 1px rgba(255, 255, 255, 0) inset, 0 1px rgba(255, 255, 255, 0);
 	--gnome-button-suggested-action-background: linear-gradient(to top, #2379e2 2px, #3584e4);
 	--gnome-button-suggested-action-border-color: #1b6acb;
@@ -76,7 +79,7 @@
 	--gnome-entry-box-shadow: none;
 	--gnome-entry-color: #020202;
 	--gnome-inactive-entry-background: linear-gradient(#fcfcfc, #fcfcfc);
-	--gnome-inactive-entry-border-color: #c0c0bd;
+	--gnome-inactive-entry-border-color: #d5d0cc;
 	--gnome-inactive-entry-box-shadow: none;
 	--gnome-inactive-entry-color: #323232;
 	--gnome-focused-urlbar-border-color: #4a90d9;
@@ -92,17 +95,20 @@
 	--gnome-switch-active-slider-border-color: #185fb4;
 
 	/* Tabs */
-	--gnome-tabbar-tab-color: rgb(141, 144, 145);
+	--gnome-tabbar-tab-color: #2e3436;
+	--gnome-tabbar-tab-background: #e1dedb;
+	--gnome-tabbar-tab-border-color: #dbd7d4;
 	--gnome-tabbar-tab-hover-background: #e4e2de;
 	--gnome-tabbar-tab-hover-border-bottom-color: #b6b6b3;
-	--gnome-tabbar-tab-hover-color: rgb(93, 98, 99);
-	--gnome-tabbar-tab-active-background: #eae8e6;
+	--gnome-tabbar-tab-hover-color: #2e3436;
+	--gnome-tabbar-tab-active-background: #ebe9e7;
 	--gnome-tabbar-tab-active-background-contrast: #F7F5F3;
 	--gnome-tabbar-tab-active-border-bottom-color: #4a90d9;
 	--gnome-tabbar-tab-active-border-bottom-color-contrast: #4a90d9;
-	--gnome-tabbar-tab-active-color: rgb(46, 52, 54);
+	--gnome-tabbar-tab-active-color: #2e3436;
 	--gnome-tabbar-tab-active-hover-background: #e6e6e6;
-	--gnome-inactive-tabbar-tab-color: #8b8e8f;
+	--gnome-inactive-tabbar-tab-color: #929595;
+	--gnome-inactive-tabbar-tab-background: #eae8e6;
 	--gnome-inactive-tabbar-tab-active-background: #f6f5f4;
 	--gnome-inactive-tabbar-tab-active-border-bottom-color: var(--gnome-tabbar-tab-active-border-bottom-color);
 	--gnome-inactive-tabbar-tab-active-color: var(--gnome-inactive-tabbar-tab-color);

--- a/theme/parts/icons.css
+++ b/theme/parts/icons.css
@@ -33,10 +33,14 @@ menuitem[type="radio"][checked="true"],
 :root[tabsintitlebar] #titlebar .titlebar-buttonbox .titlebar-min .toolbarbutton-icon,
 :root[tabsintitlebar] #titlebar #titlebar-min .toolbarbutton-icon,
 :root[tabsintitlebar][inFullscreen] #window-controls #restore-button .toolbarbutton-icon {
-	fill: var(--gnome-toolbar-color) !important;
+	fill: var(--gnome-toolbar-icon-fill) !important;
 	fill-opacity: 1 !important;
 	-moz-context-properties: fill, fill-opacity;
 }
+.toolbarbutton-icon:-moz-window-inactive {
+	fill: var(--gnome-inactive-toolbar-icon-fill) !important;
+}
+
 .protections-popup-category::after,
 .PanelUI-subView .subviewbutton-nav::after {
 	fill-opacity: 0.6 !important;

--- a/theme/parts/tabsbar.css
+++ b/theme/parts/tabsbar.css
@@ -16,6 +16,15 @@
 	height: auto !important;
 	min-height: auto !important;
 }
+
+#TabsToolbar {
+	background-color: var(--gnome-tabbar-tab-background) !important;
+}
+
+#TabsToolbar:-moz-window-inactive {
+	background-color: var(--gnome-inactive-tabbar-tab-background) !important;
+}
+
 tab > stack {
 	height: 38px !important;
 	min-height: 38px !important;
@@ -55,6 +64,7 @@ tab > stack {
 .tabbrowser-tab::before {
 	border-color: transparent !important;
 	border-image: none !important;
+	border-width: 0 !important;
 }
 
 /* Space between tabs */
@@ -66,7 +76,7 @@ tab > stack {
 tab {
 	color: var(--gnome-tabbar-tab-color) !important;
 	font-family: Cantarell, inherit;
-	font-weight: bold;
+	font-weight: normal;
 	font-size: 1em;
 }
 tab:hover {
@@ -74,12 +84,16 @@ tab:hover {
 }
 tab[selected] {
 	color: var(--gnome-tabbar-tab-active-color) !important;
+	border-left: 1px solid var(--gnome-tabbar-tab-border-color) !important;
+	border-right: 1px solid var(--gnome-tabbar-tab-border-color) !important;
 }
 tab:-moz-window-inactive {
 	color: var(--gnome-inactive-tabbar-tab-color) !important;
 }
 tab[selected]:-moz-window-inactive {
 	color: var(--gnome-inactive-tabbar-tab-active-color) !important;
+	border-left: 1px solid var(--gnome-inactive-headerbar-border-color) !important;
+	border-right: 1px solid var(--gnome-inactive-headerbar-border-color) !important;
 }
 
 /* Center all inside tab */
@@ -200,7 +214,7 @@ tab[selected]:-moz-window-inactive {
 	background-image: none !important;
 	border: 0 !important;
 	border-image: none !important;
-	border-bottom: 3px solid var(--gnome-tabbar-tab-active-border-bottom-color) !important;
+	border-bottom: 4px solid var(--gnome-tabbar-tab-active-border-bottom-color) !important;
 }
 .tab-background[selected=true]:-moz-window-inactive {
 	background-color: var(--gnome-inactive-tabbar-tab-active-background) !important;
@@ -219,7 +233,7 @@ tab[selected]:-moz-window-inactive {
 :root:not(:-moz-window-inactive) .tabbrowser-tab:hover > .tab-stack > .tab-background:not([selected=true]) {
 	background-color: var(--gnome-tabbar-tab-hover-background) !important;
 	border-image: none !important;
-	border-bottom: 3px solid var(--gnome-tabbar-tab-hover-border-bottom-color) !important;
+	border-bottom: 4px solid var(--gnome-tabbar-tab-hover-border-bottom-color) !important;
 }
 
 /* Tabs scroll buttons hover */


### PR DESCRIPTION
Makes the tab appearance closer to Adwaita Light and Dark and fixes colours of icons when window is inactive

![Web Active](https://user-images.githubusercontent.com/30577011/87875481-c2b1c700-c9d1-11ea-8438-8860174e6cbc.png)
![Firefox Active](https://user-images.githubusercontent.com/30577011/87875483-c34a5d80-c9d1-11ea-996a-5baa239059ee.png)
![Web Inactive](https://user-images.githubusercontent.com/30577011/87875480-c2193080-c9d1-11ea-96c5-434a2f5c16ed.png)
![Firefox Inactive](https://user-images.githubusercontent.com/30577011/87875482-c2b1c700-c9d1-11ea-8aa0-b2f1065db589.png)
