### PR TITLE
Added a installation script that can be curled

### DIFF
--- a/scripts/install-by-curl.sh
+++ b/scripts/install-by-curl.sh
@@ -12,6 +12,7 @@ cd $FOLDERPATH
 curl -LJo $FILENAME https://github.com/rafaelmardojai/firefox-gnome-theme/tarball/$VERSION
 
 tar -xzf $FILENAME --strip-components=1
+rm $FILENAME
 
 chmod +x scripts/install.sh
 ./scripts/install.sh

--- a/scripts/install-by-curl.sh
+++ b/scripts/install-by-curl.sh
@@ -1,0 +1,19 @@
+
+VERSION=$(curl -s "https://github.com/rafaelmardojai/firefox-gnome-theme/releases/latest/download" 2>&1 | sed "s/^.*download\/\([^\"]*\).*/\1/")
+FILENAME=firefox-gnome-theme-$VERSION.tar.gz
+FOLDERPATH=$PWD/firefox-gnome-theme-$VERSION
+
+if [ -d "$FOLDERPATH" ]; then rm -Rf $FOLDERPATH; fi
+
+mkdir $FOLDERPATH
+
+cd $FOLDERPATH
+
+curl -LJo $FILENAME https://github.com/rafaelmardojai/firefox-gnome-theme/tarball/$VERSION
+
+tar -xzf $FILENAME --strip-components=1
+
+chmod +x scripts/install.sh
+./scripts/install.sh
+
+if [ -d "$FOLDERPATH" ]; then rm -Rf $FOLDERPATH; fi

--- a/scripts/install-by-curl.sh
+++ b/scripts/install-by-curl.sh
@@ -1,7 +1,7 @@
 
 VERSION=$(curl -s "https://github.com/rafaelmardojai/firefox-gnome-theme/releases/latest/download" 2>&1 | sed "s/^.*download\/\([^\"]*\).*/\1/")
 FILENAME=firefox-gnome-theme-$VERSION.tar.gz
-FOLDERPATH=$PWD/firefox-gnome-theme-$VERSION
+FOLDERPATH=$PWD/firefox-gnome-theme
 
 if [ -d "$FOLDERPATH" ]; then rm -Rf $FOLDERPATH; fi
 


### PR DESCRIPTION
With this pr, we'll be able to install this theme with only one command!
simply run 
`curl -s -o- https://raw.githubusercontent.com/dyegoaurelio/firefox-gnome-theme/curlscript/scripts/install-by-curl.sh | bash`
(when the pr is accepted just change dyegoaurelio/firefox-gnome-theme/curlscript for rafaelmardojai/firefox-gnome-theme/master from the curl command )
![Captura de tela de 2020-10-23 12-22-42](https://user-images.githubusercontent.com/42411160/97022454-82ab3480-152a-11eb-85f8-b1f14c822df9.png)

