### PR TITLE
Increase maximum height of address bar results

### DIFF
--- a/theme/parts/headerbar-urlbar.css
+++ b/theme/parts/headerbar-urlbar.css
@@ -50,7 +50,7 @@ toolbarspring {
 .urlbarView-body-outer {
 	--item-padding-start: 0 !important;
 	--item-padding-end: 0 !important;
-	max-height: 40vh !important;
+	max-height: 100vh !important;
 	overflow-x: auto;
 	padding: 0 8px !important;
 }


### PR DESCRIPTION
Increase maximum height of address bar results to avoid visual artifacts like shown in issue #188 