### PR TITLE
Set webextension popover background to white

### DIFF
--- a/theme/parts/popups-contents.css
+++ b/theme/parts/popups-contents.css
@@ -367,3 +367,8 @@
 #contextual-feature-recommendation-notification {
     width: auto !important;
 }
+
+/* Extensions sometimes assume a white background */
+.webextension-popup-browser {
+  background-color: #fff !important;
+}


### PR DESCRIPTION
fixes https://github.com/rafaelmardojai/firefox-gnome-theme/issues/198

# Before

![before](https://user-images.githubusercontent.com/1714287/107778018-79451280-6d3b-11eb-8a91-decb4a15a495.jpeg)

# After

![after](https://user-images.githubusercontent.com/1714287/107835385-4168ba00-6d91-11eb-954c-eaac97d5c88e.png)