### PR TITLE
Changed nav-bar-overflow-button icon

### DIFF
--- a/theme/parts/icons.css
+++ b/theme/parts/icons.css
@@ -319,7 +319,7 @@ menuitem[type="radio"][disabled="true"] .menu-iconic-icon {
 }
 /* Overflow button */
 #nav-bar-overflow-button {
-	list-style-image: url("../icons/view-more-horizontal-symbolic.svg") !important;
+	list-style-image: url("../icons/pan-down-symbolic.svg") !important;
 }
 /* Glitch - animations (may be possible to fix in about:config)
 #reload-button .toolbarbutton-icon { /* Reload button

--- a/theme/system-icons.css
+++ b/theme/system-icons.css
@@ -160,7 +160,7 @@
 	/* Navbar overflow button */
 	#nav-bar-overflow-button .toolbarbutton-icon {
 		filter: var(--gnome-icons-hack-filter);
-		list-style-image: url("moz-icon://stock/view-more-horizontal-symbolic?size=dialog") !important;
+		list-style-image: url("moz-icon://stock/pan-down-symbolic?size=dialog") !important;
 	}
 
 	/* Context back button */	


### PR DESCRIPTION
The default icon for `nav-bar-overflow-button` is very similar to the one used just next to it (three horizontal dots, aside with three stacked lines...)

This is surely the default gnome ui guidelines, but I found it more convenient for myself to change this icon to an arrow, more like what is used in nautilus.
It is also the kind of icon that is used for default firefox, and makes more sense (as it is used to hide elements from main panel).