### PR TITLE
fix script location in install-by-curl.sh

### DIFF
--- a/scripts/install-by-curl.sh
+++ b/scripts/install-by-curl.sh
@@ -17,6 +17,6 @@ rm $FILENAME
 
 chmod +x scripts/auto-install.sh
 
-./auto-install.sh
+./scripts/auto-install.sh
 
 if [ -d "$FOLDERPATH" ]; then rm -Rf $FOLDERPATH; fi


### PR DESCRIPTION
the install-by-curl.sh script fails because it doesn't have the correct path to the auto-install.sh script:
```
bash: line 20: ./auto-install.sh: No such file or directory
```
I've corrected the path and tested the new script to work as intended