### PR TITLE
More compatible install scripts

### DIFF
--- a/scripts/auto-install.sh
+++ b/scripts/auto-install.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 sysThemeNames=("'Pop'" "'Pop-dark'" "'Pop-light'" "'Yaru'" "'Yaru-dark'" "'Yaru-light'" "'Adwaita-maia'" "'Adwaita-maia-dark'")
 themeNames=("pop" "pop" "pop" "yaru" "yaru" "yaru" "maia" "maia")

--- a/scripts/install-by-curl.sh
+++ b/scripts/install-by-curl.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 VERSION=$(curl -s "https://github.com/rafaelmardojai/firefox-gnome-theme/releases/latest/download" 2>&1 | sed "s/^.*download\/\([^\"]*\).*/\1/")
 FILENAME=firefox-gnome-theme-$VERSION.tar.gz

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 THEMEDIRECTORY=$(cd `dirname $0` && cd .. && pwd)
 FIREFOXFOLDER=~/.mozilla/firefox


### PR DESCRIPTION
I came across some failure when installing the theme. The problem was the shebangs on the scripts. Generally "/usr/bin/env bash" is much more compatible then just using "/bin/bash" as some distributions ( for example NixOS ) does not have bash accessible on their /bin. 
