### PR TITLE
New filters hack to fix the light/dark theme issue

### DIFF
--- a/theme/system-icons.css
+++ b/theme/system-icons.css
@@ -2,13 +2,13 @@
 
 /* Icons light/dark fix coloring hack filters */
 :root {
-	--gnome-icons-hack-filter: none;
-	--gnome-window-icons-hack-filter: none;
+	--gnome-icons-hack-filter: filter: brightness(0) saturate(100%) invert(37%) sepia(8%) saturate(683%) hue-rotate(183deg) brightness(95%) contrast(84%);
+	--gnome-window-icons-hack-filter: filter: brightness(0) saturate(100%) invert(37%) sepia(8%) saturate(683%) hue-rotate(183deg) brightness(95%) contrast(84%);
 }
 @media (prefers-color-scheme: dark) {
 	:root {
-		--gnome-icons-hack-filter: invert(100%) sepia(100%) grayscale(100%) brightness(200%) brightness(200%);
-		--gnome-window-icons-hack-filter: invert(90%);
+		--gnome-icons-hack-filter: brightness(0) saturate(100%) invert(94%) sepia(11%) saturate(362%) hue-rotate(184deg) brightness(95%) contrast(87%);
+		--gnome-window-icons-hack-filter: brightness(0) saturate(100%) invert(94%) sepia(11%) saturate(362%) hue-rotate(184deg) brightness(95%) contrast(87%);
 	}
 }
 


### PR DESCRIPTION
This filter first turns the icon black, then it tries to match the Adwaita symbolic icon colours.
The filters are generated from : https://codepen.io/sosuke/pen/Pjoqqp

This way the icons are always #2e3436 for the light theme and #eeeeec for the dark theme independently of what icon-theme is in use.