### PR TITLE
Remove blue line under tabs

### DIFF
--- a/theme/parts/tabsbar.css
+++ b/theme/parts/tabsbar.css
@@ -280,11 +280,6 @@ tab[selected]:-moz-window-inactive {
 	margin-top: 0 !important;
 }
 
-/* Remove blue line above tabs */
-.tab-line {
-	display: none;
-}
-
 /* Active tab */
 .tab-background[selected=true] {
 	background-color: var(--gnome-tabbar-tab-active-background) !important;


### PR DESCRIPTION
Since Firefox 89.0 there are no longer blue lines under the tabs. I believe this is no longer necessary.