### PR TITLE
detect snap folder for autoinstall and install scripts

### DIFF
--- a/scripts/auto-install.sh
+++ b/scripts/auto-install.sh
@@ -6,6 +6,7 @@ themeNames=("pop" "pop" "pop" "yaru" "yaru" "yaru" "maia" "maia")
 firefoxInstalationPaths=(
     ~/.mozilla/firefox
     ~/.var/app/org.mozilla.firefox/.mozilla/firefox
+    ~/snap/firefox/common/.mozilla/firefox
 )
 
 currentTheme=$(gsettings get org.gnome.desktop.interface gtk-theme ) || currentTheme=""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
 THEMEDIRECTORY=$(cd `dirname $0` && cd .. && pwd)
-FIREFOXFOLDER=~/.mozilla/firefox
+if [[ -f "~/snap" ]]
+    then
+    FIREFOXFOLDER=~/snap/firefox/common/.mozilla/firefox
+    else
+    FIREFOXFOLDER=~/.mozilla/firefox
+fi
 PROFILENAME=""
 THEME=DEFAULT
 


### PR DESCRIPTION
make scripts aware of snap version of firefox on ubuntu >= 21.10