### PR TITLE
Update dark and light/dark private themes

### DIFF
--- a/theme/colors/dark.css
+++ b/theme/colors/dark.css
@@ -117,34 +117,34 @@
 
 	/* Private window colors */
 	:root {
-		--gnome-private-accent: rgb(158, 70, 224);
+		--gnome-private-accent: #5A79A4;
 		
 		/* Header bar */
-		--gnome-private-headerbar-background: linear-gradient(to top, rgb(81, 44, 109), rgb(86, 47, 116));
-		--gnome-private-headerbar-border-color: rgb(49, 27, 66);
-		--gnome-private-headerbar-box-shadow: 0 1px rgba(255, 255, 255, .07) inset;
-		--gnome-private-inactive-headerbar-background: #613583;
-		--gnome-private-inactive-headerbar-border-color: rgb(77, 41, 102);
+		--gnome-private-headerbar-background: #252F49;
+		--gnome-private-headerbar-border-color: #3F475E;
+		--gnome-private-headerbar-box-shadow: none;
+		--gnome-private-inactive-headerbar-background: #1C2438;
+		--gnome-private-inactive-headerbar-border-color: #3A4152;
 		--gnome-private-inactive-headerbar-box-shadow: var(--gnome-private-headerbar-box-shadow);
 
 		/* Buttons */
-		--gnome-private-button-background: linear-gradient(to top, rgb(94, 52, 127) 2px, rgb(97, 53, 131));
-		--gnome-private-button-border-color: rgb(70, 38, 95);
-		--gnome-private-button-border-accent-color: rgb(49, 27, 66);
-		--gnome-private-button-box-shadow: 0 1px rgba(255, 255, 255, .02) inset, 0 1px 2px rgba(0, 0, 0, .07);
-		--gnome-private-button-hover-background: linear-gradient(to top, rgb(94, 52, 127), rgb(100, 54, 135) 1px);
-		--gnome-private-button-active-background: rgb(73, 40, 98);
-		--gnome-private-button-active-border-color: rgb(62, 34, 84);
-		--gnome-private-button-active-border-accent-color: rgb(49, 27, 66);
-		--gnome-private-button-active-box-shadow: 0 1px rgba(255, 255, 255, 0) inset;
-		--gnome-private-button-disabled-background: #613583;
-		--gnome-private-button-disabled-border-color: rgb(74, 41, 102);
-		--gnome-private-button-disabled-box-shadow:  0 1px rgba(255, 255, 255, 0) inset;
-		--gnome-private-inactive-button-background: #613583;
-		--gnome-private-inactive-button-border-color: rgb(74, 41, 102);
-		--gnome-private-inactive-button-box-shadow:  0 1px rgba(255, 255, 255, 0) inset;
+		--gnome-private-button-background: #252F49;
+		--gnome-private-button-border-color: none;
+		--gnome-private-button-border-accent-color: none;
+		--gnome-private-button-box-shadow: none;
+		--gnome-private-button-hover-background: #343E56;
+		--gnome-private-button-active-background: var(--gnome-private-button-background);
+		--gnome-private-button-active-border-color: none;
+		--gnome-private-button-active-border-accent-color: none;
+		--gnome-private-button-active-box-shadow: none;
+		--gnome-private-button-disabled-background: #252F49;
+		--gnome-private-button-disabled-border-color: none;
+		--gnome-private-button-disabled-box-shadow:  none;
+		--gnome-private-inactive-button-background: #1C2438;
+		--gnome-private-inactive-button-border-color: none;
+		--gnome-private-inactive-button-box-shadow:  none;
 
 		/* Entries */
-		--gnome-private-entry-border-color: #202020;
+		--gnome-private-entry-border-color: none;
 	}
 }

--- a/theme/colors/dark.css
+++ b/theme/colors/dark.css
@@ -7,82 +7,82 @@
 @media (prefers-color-scheme: dark) {
 	:root {
 		/* Browser area before a page starts loading */
-		--gnome-browser-before-load-background: #353535;
+		--gnome-browser-before-load-background: #242424;
 		
 		/* Accent */
-		--gnome-accent: #15539e;
+		--gnome-accent: #5F7999;
 
 		/* Toolbars */
-		--gnome-toolbar-background: #282828;
+		--gnome-toolbar-background: #242424;
 		--gnome-toolbar-color: #ffffff;
-		--gnome-toolbar-border-color: #1b1b1b;
+		--gnome-toolbar-border-color: #4E4E4E;
 		--gnome-toolbar-icon-fill: #eeeeec;
 		--gnome-inactive-toolbar-color: #919190;
-		--gnome-inactive-toolbar-background: #353535;
-		--gnome-inactive-toolbar-border-color: #202020;
+		--gnome-inactive-toolbar-background: #1C1C1C;
+		--gnome-inactive-toolbar-border-color: #3F3F3F;
 		--gnome-inactive-toolbar-icon-fill: #919190;
 
 		/* Sidebar */
-		--gnome-sidebar-background: #313131;
-		--gnome-inactive-sidebar-background: #323232;
+		--gnome-sidebar-background: #242424;
+		--gnome-inactive-sidebar-background: var(--gnome-sidebar-background);
 
 		/* Popups */
 		--gnome-menu-background: #2f2f2f;
 		--gnome-menu-border-color: #1b1b1b;
-		--gnome-popover-background: #353535;
+		--gnome-popover-background: #383838;
 		--gnome-popover-border-color: #1b1b1b;
 		--gnome-popover-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
-		--gnome-popover-button-hover-background: #424242;
+		--gnome-popover-button-hover-background: #4C4C4C;
 		--gnome-popover-separator-color: rgba(0, 0, 0, 0.1);
 
 		/* Header bar */
-		--gnome-headerbar-background: linear-gradient(to top, #262626, #2b2b2b);
-		--gnome-headerbar-border-color: #070707;
-		--gnome-headerbar-box-shadow: inset 0 1px rgba(238, 238, 236, 0.07);
-		--gnome-inactive-headerbar-background: linear-gradient(#353535, #353535);
-		--gnome-inactive-headerbar-border-color: #202020;
+		--gnome-headerbar-background: #303030;
+		--gnome-headerbar-border-color: #4E4E4E;
+		--gnome-headerbar-box-shadow: none;
+		--gnome-inactive-headerbar-background: #242424;
+		--gnome-inactive-headerbar-border-color: #3F3F3F;
 		--gnome-inactive-headerbar-box-shadow: inset 0 1px rgba(238, 238, 236, 0.07);
 
 		/* Buttons */
-		--gnome-button-background: linear-gradient(to top, #323232 2px, #353535);
-		--gnome-button-border-color: #1b1b1b;
-		--gnome-button-border-accent-color: #070707;
-		--gnome-button-box-shadow: inset 0 1px rgba(255, 255, 255, 0.02), 0 1px 2px rgba(0, 0, 0, 0.07);
-		--gnome-button-hover-background: linear-gradient(to top, #323232, #373737 1px);
-		--gnome-button-active-background: linear-gradient(#1e1e1e, #1e1e1e);
-		--gnome-button-active-border-color: #1b1b1b;
+		--gnome-button-background: #303030;
+		--gnome-button-border-color: none;
+		--gnome-button-border-accent-color: none;
+		--gnome-button-box-shadow: none;
+		--gnome-button-hover-background: #3E3E3E;
+		--gnome-button-active-background: #454545;
+		--gnome-button-active-border-color: none;
 		--gnome-button-active-border-accent-color: #000000;
 		--gnome-button-active-box-shadow: inset 0 1px rgba(255, 255, 255, 0);
-		--gnome-button-disabled-background: #323232;
-		--gnome-button-disabled-border-color: #202020;
-		--gnome-button-disabled-box-shadow: inset 0 1px rgba(255, 255, 255, 0);
-		--gnome-inactive-button-background: linear-gradient(#353535, #353535);
-		--gnome-inactive-button-border-color: #202020;
+		--gnome-button-disabled-background: var(--gnome-button-background);
+		--gnome-button-disabled-border-color: none;
+		--gnome-button-disabled-box-shadow: none;
+		--gnome-inactive-button-background: #242424;
+		--gnome-inactive-button-border-color: none;
 		--gnome-inactive-button-box-shadow: inset 0 1px rgba(255, 255, 255, 0);
 		--gnome-button-suggested-action-background: linear-gradient(to top, #155099 2px, #15539e);
-		--gnome-button-suggested-action-border-color: #0f3b71;
+		--gnome-button-suggested-action-border-color: none;
 		--gnome-button-suggested-action-border-accent-color: #092444;
 		--gnome-button-suggested-action-box-shadow: inset 0 1px rgba(255, 255, 255, 0.02), 0 1px 2px rgba(0, 0, 0, 0.07);
 		--gnome-button-suggested-action-hover-background: linear-gradient(to top, #155099, #1655a2 1px);
 		--gnome-button-suggested-action-active-background: #103e75;
 		--gnome-button-suggested-action-active-border-color: #0f3b71;
 		--gnome-button-suggested-action-active-box-shadow: inset 0 1px rgba(255, 255, 255, 0);
-		--gnome-button-destructive-action-background: linear-gradient(to top, #ae151c 2px, #b2161d);
-		--gnome-button-destructive-action-border-color: #851015;
+		--gnome-button-destructive-action-background: var(--gnome-button-background);
+		--gnome-button-destructive-action-border-color: #3E3E3E;
 		--gnome-button-destructive-action-border-accent-color: #570b0e;
 		--gnome-button-destructive-action-box-shadow: inset 0 1px rgba(255, 255, 255, 0.02), 0 1px 2px rgba(0, 0, 0, 0.07);
 		--gnome-button-destructive-action-hover-background: linear-gradient(to top, #ae151c, #b7161d 1px);
-		--gnome-button-destructive-action-active-background: #8a1116;
-		--gnome-button-destructive-action-active-border-color: #851015;
+		--gnome-button-destructive-action-active-background: #3D3E3D;
+		--gnome-button-destructive-action-active-border-color: none;
 		--gnome-button-destructive-action-active-box-shadow: inset 0 1px rgba(255, 255, 255, 0);
 
 		/* Entries */
-		--gnome-entry-background: linear-gradient(#2d2d2d, #2d2d2d);
-		--gnome-entry-border-color: #1b1b1b;
-		--gnome-entry-box-shadow: inset 0 0 0 1px rgba(21, 83, 158, 0);
+		--gnome-entry-background: #454545;
+		--gnome-entry-border-color: none;
+		--gnome-entry-box-shadow: none;
 		--gnome-entry-color: #ffffff;
-		--gnome-inactive-entry-background: linear-gradient(#303030, #303030);
-		--gnome-inactive-entry-border-color: #202020;
+		--gnome-inactive-entry-background: var(--gnome-entry-background);
+		--gnome-inactive-entry-border-color: none;
 		--gnome-inactive-entry-box-shadow: none;
 		--gnome-inactive-entry-color: #d6d6d6;
 		--gnome-focused-urlbar-border-color: var(--gnome-accent);
@@ -101,18 +101,18 @@
 		/* Tabs */
 		--gnome-tabbar-tab-color: rgb(141, 144, 145);
 		--gnome-tabbar-tab-background: #262626;
-		--gnome-tabbar-tab-border-color: #070707;
+		--gnome-tabbar-tab-border-color: #4E4E4E;
 		--gnome-tabbar-tab-hover-background: #2d2d2d;
 		--gnome-tabbar-tab-hover-color: rgb(200, 200, 200);
-		--gnome-tabbar-tab-active-background: #353535;
-		--gnome-tabbar-tab-active-background-contrast: #4c4c4c;
+		--gnome-tabbar-tab-active-background: #303030;
+		--gnome-tabbar-tab-active-background-contrast: #4F4F4F;
 		--gnome-tabbar-tab-active-color: #ffffff;
-		--gnome-tabbar-tab-active-hover-background: #3c3c3c;
+		--gnome-tabbar-tab-active-hover-background: #363636;
 		--gnome-inactive-tabbar-tab-color: rgb(141, 144, 145);
-		--gnome-inactive-tabbar-tab-background: #2e2e2e;
-		--gnome-inactive-tabbar-tab-active-background: #353535;
+		--gnome-inactive-tabbar-tab-background: #1C1C1C;
+		--gnome-inactive-tabbar-tab-active-background: #242424;
 		--gnome-inactive-tabbar-tab-active-color: rgb(141, 144, 145);
-		--gnome-tabbar-close-hover: #565656;
+		--gnome-tabbar-close-hover: #444444;
 	}
 
 	/* Private window colors */

--- a/theme/colors/dark.css
+++ b/theme/colors/dark.css
@@ -117,7 +117,7 @@
 
 	/* Private window colors */
 	:root {
-		--gnome-private-accent: #5A79A4;
+		--gnome-private-accent: #71A1DB;
 		
 		/* Header bar */
 		--gnome-private-headerbar-background: #252F49;

--- a/theme/colors/light.css
+++ b/theme/colors/light.css
@@ -117,34 +117,34 @@
 
 /* Private window colors */
 :root {
-	--gnome-private-accent: rgb(132, 77, 179);
+	--gnome-private-accent: #272F42;
 	
 	/* Header bar */
-	--gnome-private-headerbar-background: linear-gradient(to top, rgb(206, 191, 219), rgb(214, 201, 255));
-	--gnome-private-headerbar-border-color: rgb(176, 152, 197);
-	--gnome-private-headerbar-box-shadow: 0 1px rgba(255, 255, 255, .8) inset;
-	--gnome-private-inactive-headerbar-background: #ECE6F1;
-	--gnome-private-inactive-headerbar-border-color: rgb(200, 183, 215);
+	--gnome-private-headerbar-background: #D7E3F0;
+	--gnome-private-headerbar-border-color: #BEC9D5;
+	--gnome-private-headerbar-box-shadow: none;
+	--gnome-private-inactive-headerbar-background: #EAF0F7;
+	--gnome-private-inactive-headerbar-border-color: #D8DEE4;
 	--gnome-private-inactive-headerbar-box-shadow: var(--gnome-private-headerbar-box-shadow);
 
 	/* Buttons */
-	--gnome-private-button-background: linear-gradient(to top, rgb(226, 217, 234) 2px, rgb(236, 230, 241));
-	--gnome-private-button-border-color: rgb(191, 171, 208);
-	--gnome-private-button-border-accent-color: rgb(179, 152, 197);
-	--gnome-private-button-box-shadow: 0 1px rgba(255, 255, 255, .8) inset, 0 1px 2px rgba(0, 0, 0, .07);
-	--gnome-private-button-hover-background: linear-gradient(to top, rgb(236, 230, 241), rgb(238, 233, 243) 1px);
-	--gnome-private-button-active-background: rgb(194, 174, 210);
-	--gnome-private-button-active-border-color: rgb(184, 161, 203);
-	--gnome-private-button-active-border-accent-color: rgb(171, 145, 194);
-	--gnome-private-button-active-box-shadow: 0 1px rgba(255, 255, 255, 0) inset;
-	--gnome-private-button-disabled-background: #ECE6F1;
-	--gnome-private-button-disabled-border-color: rgb(200, 183, 215);
-	--gnome-private-button-disabled-box-shadow:  0 1px rgba(255, 255, 255, 0) inset;
-	--gnome-private-inactive-button-background: #ECE6F1;
-	--gnome-private-inactive-button-border-color: rgb(200, 183, 215);
-	--gnome-private-inactive-button-box-shadow:  0 1px rgba(255, 255, 255, 0) inset;
+	--gnome-private-button-background: #D7E3F0;
+	--gnome-private-button-border-color: none;
+	--gnome-private-button-border-accent-color: none;
+	--gnome-private-button-box-shadow: none;
+	--gnome-private-button-hover-background: #CBD6E3;
+	--gnome-private-button-active-background: var(--gnome-private-button-background);
+	--gnome-private-button-active-border-color: none;
+	--gnome-private-button-active-border-accent-color: none;
+	--gnome-private-button-active-box-shadow: none;
+	--gnome-private-button-disabled-background: #D7E3F0;
+	--gnome-private-button-disabled-border-color: none;
+	--gnome-private-button-disabled-box-shadow: none;
+	--gnome-private-inactive-button-background: #EAF0F7;
+	--gnome-private-inactive-button-border-color: none;
+	--gnome-private-inactive-button-box-shadow: none;
 
 	/* Entries */
-	--gnome-private-entry-border-color: rgb(191, 171, 208);
+	--gnome-private-entry-border-color: none;
 }
 


### PR DESCRIPTION
There is room for improvement here, mostly for dark theme. Private themes try to match Epiphany's GTK4 port changes, although they might not be perfect with Firefox's colors 😕 

![Captura desde 2022-03-25 17-08-10](https://user-images.githubusercontent.com/42654671/160163443-253a2db5-f5a4-4d60-9281-f2bf7ff19a74.png)
![Captura desde 2022-03-25 17-08-28](https://user-images.githubusercontent.com/42654671/160163442-cb422dda-6222-4d8d-903f-b3650b273c71.png)
![Captura desde 2022-03-25 17-08-42](https://user-images.githubusercontent.com/42654671/160163436-627b88ef-3a17-4959-af61-cc2b255c8751.png)