### PR TITLE
Update close button to match with libadwaita style

### DIFF
--- a/theme/colors/dark.css
+++ b/theme/colors/dark.css
@@ -44,6 +44,7 @@
 		--gnome-inactive-headerbar-box-shadow: inset 0 1px rgba(238, 238, 236, 0.07);
 
 		/* Buttons */
+		--gnome-button-close-background: #444444;
 		--gnome-button-background: #303030;
 		--gnome-button-border-color: none;
 		--gnome-button-border-accent-color: none;

--- a/theme/colors/light.css
+++ b/theme/colors/light.css
@@ -44,6 +44,7 @@
 	--gnome-inactive-headerbar-box-shadow: 0 1px #fff inset;
 
 	/* Buttons */
+	--gnome-button-close-background: #D9D9D9;
 	--gnome-button-background: #EBEBEB;
 	--gnome-button-border-color: none;
 	--gnome-button-border-accent-color: none;

--- a/theme/parts/csd.css
+++ b/theme/parts/csd.css
@@ -127,9 +127,9 @@
 
 :root[tabsintitlebar] #titlebar .titlebar-button {
 	border-radius: 100% !important;
-	height: 22px !important;
-	margin: 7px 15px !important;
-	width: 22px !important;
+	height: 24px !important;
+	margin: 5px 7px !important;
+	width: 24px !important;
 }
 
 :root[tabsintitlebar][inFullscreen] #window-controls toolbarbutton {
@@ -143,8 +143,8 @@
 :root[tabsintitlebar][inFullscreen] #window-controls toolbarbutton .toolbarbutton-icon {
 	width: 16px;
 }
-:root[tabsintitlebar] #titlebar:-moz-window-inactive .titlebar-button .toolbarbutton-icon,
-:root[tabsintitlebar][inFullscreen] #window-controls:-moz-window-inactive toolbarbutton .toolbarbutton-icon {
+:root[tabsintitlebar] #titlebar:-moz-window-inactive .titlebar-button,
+:root[tabsintitlebar][inFullscreen] #window-controls:-moz-window-inactive toolbarbutton {
 	opacity: .3 !important;
 }
 :root[tabsintitlebar] #titlebar:not(:-moz-window-inactive) .titlebar-button:not([disabled]):hover,


### PR DESCRIPTION
This kinda messes up dark mode buttons. When #352 gets merged `--gnome-button-close-background` should be added for dark theme. :hover and :active are not added yet