### PR TITLE
Overlay scrollbar to widget.gtk settings

### DIFF
--- a/configuration/user.js
+++ b/configuration/user.js
@@ -12,4 +12,4 @@ user_pref("browser.uidensity", 0);
 user_pref("svg.context-properties.content.enabled", true);
 
 // Enable overlay scrollbars
-user_pref("ui.useOverlayScrollbars", 1);
+user_pref("widget.gtk.overlay-scrollbars.enabled", true);


### PR DESCRIPTION
Since Firefox 99 there is an "official" overlay scrollbars settings into Firefox, this PR propose to use it instead of the old (hidden settings).