### PR TITLE
Tab colors and Url bar

### DIFF
--- a/theme/colors/dark.css
+++ b/theme/colors/dark.css
@@ -103,11 +103,11 @@
 
 		/* Tabs */
 		--gnome-tabbar-tab-color: rgb(141, 144, 145);
-		--gnome-tabbar-tab-background: #262626;
-		--gnome-tabbar-tab-border-color: #4E4E4E;
-		--gnome-tabbar-tab-hover-background: #2d2d2d;
+		--gnome-tabbar-tab-background: #303030;
+		--gnome-tabbar-tab-border-color: #454545;
+		--gnome-tabbar-tab-hover-background: #3F3F3F;
 		--gnome-tabbar-tab-hover-color: rgb(200, 200, 200);
-		--gnome-tabbar-tab-active-background: #303030;
+		--gnome-tabbar-tab-active-background: #444444;
 		--gnome-tabbar-tab-active-background-contrast: #4F4F4F;
 		--gnome-tabbar-tab-active-color: #ffffff;
 		--gnome-tabbar-tab-active-hover-background: #363636;

--- a/theme/colors/dark.css
+++ b/theme/colors/dark.css
@@ -44,7 +44,6 @@
 		--gnome-inactive-headerbar-box-shadow: inset 0 1px rgba(238, 238, 236, 0.07);
 
 		/* Buttons */
-		--gnome-button-close-background: #444444;
 		--gnome-button-background: #303030;
 		--gnome-button-border-color: none;
 		--gnome-button-border-accent-color: none;
@@ -76,6 +75,9 @@
 		--gnome-button-destructive-action-active-background: #3D3E3D;
 		--gnome-button-destructive-action-active-border-color: none;
 		--gnome-button-destructive-action-active-box-shadow: inset 0 1px rgba(255, 255, 255, 0);
+		--gnome-button-close-background: #444444;
+		--gnome-button-active-close-background: #6F6F6F;
+		--gnome-button-hover-close-background: #4f4f4f;
 
 		/* Entries */
 		--gnome-entry-background: #454545;

--- a/theme/colors/light.css
+++ b/theme/colors/light.css
@@ -44,7 +44,6 @@
 	--gnome-inactive-headerbar-box-shadow: 0 1px #fff inset;
 
 	/* Buttons */
-	--gnome-button-close-background: #D9D9D9;
 	--gnome-button-background: #EBEBEB;
 	--gnome-button-border-color: none;
 	--gnome-button-border-accent-color: none;
@@ -76,6 +75,9 @@
 	--gnome-button-destructive-action-active-background: #E4E2E0;
 	--gnome-button-destructive-action-active-border-color: none;
 	--gnome-button-destructive-action-active-box-shadow: inset 0 1px rgba(255, 255, 255, 0);
+	--gnome-button-close-background: #D9D9D9;
+	--gnome-button-active-close-background: #B3B3B3;
+	--gnome-button-hover-close-background: #CECECE;
 
 	/* Entries */
 	--gnome-entry-background: #D9D9D9;

--- a/theme/colors/light.css
+++ b/theme/colors/light.css
@@ -80,7 +80,7 @@
 	--gnome-button-hover-close-background: #CECECE;
 
 	/* Entries */
-	--gnome-entry-background: #D9D9D9;
+	--gnome-entry-background: #D6D6D6;
 	--gnome-entry-border-color: none;
 	--gnome-entry-box-shadow: none;
 	--gnome-entry-color: #303030;
@@ -89,7 +89,7 @@
 	--gnome-inactive-entry-box-shadow: none;
 	--gnome-inactive-entry-color: #303030;
 	--gnome-focused-urlbar-border-color: var(--gnome-accent);
-	--gnome-focused-urlbar-item-hover: var(--gnome-toolbar-background);
+	--gnome-focused-urlbar-item-hover: #EDEDED;
 
 	/* Switch */
 	--gnome-switch-background: #e1dedb;
@@ -103,11 +103,11 @@
 
 	/* Tabs */
 	--gnome-tabbar-tab-color: #303030;
-	--gnome-tabbar-tab-background: #E1E1E1;
-	--gnome-tabbar-tab-border-color: #CECECE;
-	--gnome-tabbar-tab-hover-background: #DCDCDC;
+	--gnome-tabbar-tab-background: #EBEBEB;
+	--gnome-tabbar-tab-border-color: #D9D9D9;
+	--gnome-tabbar-tab-hover-background: #DEDEDE;
 	--gnome-tabbar-tab-hover-color: #303030;
-	--gnome-tabbar-tab-active-background: #EBEBEB;
+	--gnome-tabbar-tab-active-background: #D9D9D9;
 	--gnome-tabbar-tab-active-background-contrast: #FAFAFA;
 	--gnome-tabbar-tab-active-color: #303030;
 	--gnome-tabbar-tab-active-hover-background: #E5E5E5;

--- a/theme/parts/csd.css
+++ b/theme/parts/csd.css
@@ -128,7 +128,7 @@
 :root[tabsintitlebar] #titlebar .titlebar-button {
 	border-radius: 100% !important;
 	height: 24px !important;
-	margin: 5px 7px !important;
+	margin: 6px 6px !important;
 	width: 24px !important;
 }
 
@@ -156,9 +156,13 @@
 }
 :root[tabsintitlebar] #titlebar:not(:-moz-window-inactive) .titlebar-button:not([disabled]):active,
 :root[tabsintitlebar][inFullscreen] #window-controls:not(:-moz-window-inactive) toolbarbutton:not([disabled]):active {
-	background: var(--gnome-button-active-background);
+	background: var(--gnome-button-active-close-background);
 	box-shadow: var(--gnome-button-active-box-shadow);
 	border-color: var(--gnome-button-active-border-color) !important;
+}
+
+:root[tabsintitlebar] #titlebar .titlebar-button:where(:hover) {
+	background: var(--gnome-button-hover-close-background);
 }
 
 /* OPTIONAL: Allow draging the window from headerbar buttons */

--- a/theme/parts/urlbar.css
+++ b/theme/parts/urlbar.css
@@ -53,7 +53,7 @@ toolbarspring {
 	--item-padding-start: 0 !important;
 	--item-padding-end: 0 !important;
 	overflow-x: auto;
-	padding: 0 8px !important;
+	padding: 0 20px !important;
 }
 
 .urlbarView-body-inner {


### PR DESCRIPTION
Color improvement according to Libadwaita's new tab
I hope the next update will be mimicking the new tabs completely.
![Captura de tela de 2022-04-28 22-19-29](https://user-images.githubusercontent.com/54215258/165877942-89806a58-f289-48f5-a8c6-45c22dbf0ff6.png)
![image](https://user-images.githubusercontent.com/54215258/165878207-2a50dfc2-1bf1-43ee-bf8a-6b5ba37d8aa7.png)

![Captura de tela de 2022-04-27 01-06-49](https://user-images.githubusercontent.com/54215258/165877978-125e9073-44ca-417b-8c4f-591ae6af0a1c.png)
![image](https://user-images.githubusercontent.com/54215258/165878175-be734686-b388-45e7-ba71-24777b0bd7ed.png)

I also increased the padding of the url bar view.
![image](https://user-images.githubusercontent.com/54215258/165879224-a3c20e99-4e48-4cd1-a1d7-807afd8f073d.png)



