### PR TITLE
Fix install-by-curl.sh

### DIFF
--- a/scripts/install-by-curl.sh
+++ b/scripts/install-by-curl.sh
@@ -1,22 +1,16 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 VERSION=$(curl --silent "https://api.github.com/repos/rafaelmardojai/firefox-gnome-theme/releases/latest" | grep tag_name | cut -d'"' -f4)
 FILENAME=firefox-gnome-theme-$VERSION.tar.gz
-FOLDERPATH=$PWD/firefox-gnome-theme
 
-if [ -d "$FOLDERPATH" ]; then rm -Rf $FOLDERPATH; fi
-
-mkdir $FOLDERPATH
-
-cd $FOLDERPATH
+(
 
 curl -LJo $FILENAME https://github.com/rafaelmardojai/firefox-gnome-theme/tarball/$VERSION
 
 tar -xzf $FILENAME --strip-components=1
-rm $FILENAME
 
 chmod +x scripts/auto-install.sh
 
 ./scripts/auto-install.sh
 
-if [ -d "$FOLDERPATH" ]; then rm -Rf $FOLDERPATH; fi
+)

--- a/scripts/install-by-curl.sh
+++ b/scripts/install-by-curl.sh
@@ -6,6 +6,8 @@ FILENAME=firefox-gnome-theme-$VERSION.tar.gz
 (
 
 cd $(mktemp -d) || exit 1
+mkdir firefox-gnome-theme
+cd firefox-gnome-theme
 
 curl -LJo $FILENAME https://github.com/rafaelmardojai/firefox-gnome-theme/tarball/$VERSION
 

--- a/scripts/install-by-curl.sh
+++ b/scripts/install-by-curl.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-VERSION=$(curl -s "https://github.com/rafaelmardojai/firefox-gnome-theme/releases/latest/download" 2>&1 | sed "s/^.*download\/\([^\"]*\).*/\1/")
+VERSION=$(curl --silent "https://api.github.com/repos/rafaelmardojai/firefox-gnome-theme/releases/latest" | grep tag_name | cut -d'"' -f4)
 FILENAME=firefox-gnome-theme-$VERSION.tar.gz
 FOLDERPATH=$PWD/firefox-gnome-theme
 

--- a/scripts/install-by-curl.sh
+++ b/scripts/install-by-curl.sh
@@ -5,6 +5,8 @@ FILENAME=firefox-gnome-theme-$VERSION.tar.gz
 
 (
 
+cd $(mktemp -d) || exit 1
+
 curl -LJo $FILENAME https://github.com/rafaelmardojai/firefox-gnome-theme/tarball/$VERSION
 
 tar -xzf $FILENAME --strip-components=1


### PR DESCRIPTION
`install-by-curl.sh` failed to fetch the `$VERSION` variable.

I also improved the script to use a subshell and a random temporary directory to avoid the need for cleanup.