### PR TITLE
Fix for options in context menu that look like disabled

### DIFF
--- a/theme/parts/popups.css
+++ b/theme/parts/popups.css
@@ -187,24 +187,24 @@ menuitem, menupopup menu,
 }
 
 /* Menu buttons disabled */
-menuitem[disabled], menupopup menu[disabled],
-.subviewbutton[disabled], .toolbarbutton-1[disabled],
-.protections-popup-category[disabled],
-.identity-popup-content-blocking-category[disabled] {
+menuitem[disabled="true"], menupopup menu[disabled="true"],
+.subviewbutton[disabled="true"], .toolbarbutton-1[disabled="true"],
+.protections-popup-category[disabled="true"],
+.identity-popup-content-blocking-category[disabled="true"] {
 	opacity: .5 !important;
 }
-menuitem[disabled][_moz-menuactive], menupopup menu[disabled][_moz-menuactive] {
+menuitem[disabled="true"][_moz-menuactive], menupopup menu[disabled="true"][_moz-menuactive] {
 	background: transparent !important;
 }
 
 /* Menu buttons hover */
-menuitem:not([disabled]):is(:hover, [_moz-menuactive]),
-menupopup menu:not([disabled]):is(:hover, [_moz-menuactive]),
-.subviewbutton:not([disabled], #appMenu-zoom-controls2, #appMenu-fxa-label2):hover,
-.protections-popup-footer-button:not([disabled]):hover,
+menuitem:not([disabled="true"]):is(:hover, [_moz-menuactive]),
+menupopup menu:not([disabled="true"]):is(:hover, [_moz-menuactive]),
+.subviewbutton:not([disabled="true"], #appMenu-zoom-controls2, #appMenu-fxa-label2):hover,
+.protections-popup-footer-button:not([disabled="true"]):hover,
 #protections-popup-show-report-stack:hover .protections-popup-footer-button,
-.protections-popup-category:not([disabled]):hover,
-.identity-popup-content-blocking-category:not([disabled]):hover,
+.protections-popup-category:not([disabled="true"]):hover,
+.identity-popup-content-blocking-category:not([disabled="true"]):hover,
 #PlacesToolbar .bookmark-item:is(:hover, [open], [_moz-menuactive]),
 #downloadsPanel-mainView .download-state:hover {
 	background: var(--gnome-menu-button-hover-background) !important;


### PR DESCRIPTION
"disabled" option without "=true" wasn't working properly, e.g. options in videos context menu looked like disabled, but were working correctly

Before:
(Options in videos context menu look like disabled, but works correctly)
![Zrzut ekranu z 2022-06-04 15-08-09](https://user-images.githubusercontent.com/49432482/172004514-2572509b-0325-4659-863b-c92311aa1ec9.png)

After:
(Options in videos context menu have correct look)
![Zrzut ekranu z 2022-06-04 15-27-04](https://user-images.githubusercontent.com/49432482/172004554-f3aea4c1-8ccf-441e-8d4d-dbc3f7c4058e.png)

