### PR TITLE
Pages: New private tab theming

### DIFF
--- a/theme/colors/dark.css
+++ b/theme/colors/dark.css
@@ -96,5 +96,14 @@
 		--gnome-private-inactive-headerbar-background: #1C2438;
 		--gnome-private-inactive-headerbar-border-color: #3A4152;
 		--gnome-private-inactive-headerbar-box-shadow: var(--gnome-private-headerbar-box-shadow);
+
+		/* Text color for Firefox Logo in new private tab */
+		--gnome-private-wordmark: #FBFBFE;
+
+		/* New private tab background */
+		--gnome-private-in-content-page-background: #1C2438;
+
+		/* Private browsing info box */
+		--gnome-private-text-primary-color: #FBFBFE;
 	}
 }

--- a/theme/colors/light.css
+++ b/theme/colors/light.css
@@ -96,5 +96,14 @@
 	--gnome-private-inactive-headerbar-background: #EAF0F7;
 	--gnome-private-inactive-headerbar-border-color: #D8DEE4;
 	--gnome-private-inactive-headerbar-box-shadow: var(--gnome-private-headerbar-box-shadow);
+
+	/* Text color for Firefox Logo in new private tab */
+	--gnome-private-wordmark: #20123A;
+
+	/* New private tab background */
+	--gnome-private-in-content-page-background: #EAF0F7;
+
+	/* Private browsing info box */
+	--gnome-private-text-primary-color: #15141A;
 }
 

--- a/theme/pages/privatebrowsing.css
+++ b/theme/pages/privatebrowsing.css
@@ -1,0 +1,16 @@
+/* about:privatebrowsing */
+
+@-moz-document url("about:privatebrowsing") {
+    html.private {
+        --in-content-page-background: var(--gnome-private-in-content-page-background) !important;
+
+        /* Used by headings in promo boxes Firefox shows (like an ad for Firefox Focus) */
+        --in-content-text-color: var(--gnome-private-text-primary-color) !important;
+    }
+    .wordmark {
+        fill: var(--gnome-private-wordmark) !important;
+    }
+    .showPrivate {
+        color: var(--gnome-private-text-primary-color);
+    }
+}

--- a/userContent.css
+++ b/userContent.css
@@ -2,3 +2,4 @@
 @import "theme/colors/dark.css";
 
 @import "theme/pages/newtab.css";
+@import "theme/pages/privatebrowsing.css"


### PR DESCRIPTION
Added CSS to theme the new private tab page(`about:privatebrowsing`) as the defaults look kinda weird with the violet background.

## Light Mode
| Before | After |
| --- | --- |
| ![before-light](https://user-images.githubusercontent.com/53053643/172640072-d6e30e83-e93d-4c36-84cb-0e0eeff876ea.png) | ![after-light](https://user-images.githubusercontent.com/53053643/172640106-387fac2b-bdb3-4714-a87d-1e2cb44a9db4.png) |

## Dark Mode
| Before | After |
| --- | --- |
| ![before-dark](https://user-images.githubusercontent.com/53053643/172640090-084be543-c2d0-4d9d-a8bb-9a6f1709d1db.png) | ![after-dark](https://user-images.githubusercontent.com/53053643/172640116-578591c7-3a8d-4d95-900b-2d3574c46925.png) |

