### PR TITLE
Fixed a missing highlight in search bar and customised the private browsing tab

### DIFF
--- a/theme/colors/dark.css
+++ b/theme/colors/dark.css
@@ -88,6 +88,7 @@
 	/* Private window colors */
 	:root {
 		--gnome-private-accent: #71A1DB;
+		--gnome-private-background: #151B2B;
 		
 		/* Header bar */
 		--gnome-private-headerbar-background: #252F49;

--- a/theme/colors/light.css
+++ b/theme/colors/light.css
@@ -88,6 +88,7 @@
 /* Private window colors */
 :root {
 	--gnome-private-accent: #272F42;
+	--gnome-private-background: #272F42;
 	
 	/* Header bar */
 	--gnome-private-headerbar-background: #D7E3F0;

--- a/theme/gnome-theme.css
+++ b/theme/gnome-theme.css
@@ -6,6 +6,7 @@
 @import "parts/tabsbar.css";
 @import "parts/findbar.css";
 @import "parts/sidebar.css";
+@import "parts/searchbar.css";
 @import "parts/lists.css";
 
 @import "parts/buttons.css";

--- a/theme/icons/indicator-private-browsing.svg
+++ b/theme/icons/indicator-private-browsing.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<svg
+   viewBox="0 0 20 20"
+   width="20"
+   height="20"
+   version="1.1"
+   id="svg10"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs14" />
+  <circle
+     fill="#8000D7"
+     cx="10"
+     cy="10"
+     r="9.5"
+     id="circle2"
+     style="fill:#345cc6;fill-opacity:1" />
+  <path
+     fill="#ffffff"
+     d="M 17.436,7.357 C 16.007,5.481 13.201,5.241 11.454,6.846 L 10.477,7.744 H 9.52 L 8.543,6.846 C 6.795,5.241 3.989,5.481 2.56,7.357 c -0.185,0.731 0.101,3.431 0.263,3.856 0.325,1.715 1.727,3.005 3.408,3.005 0.839,0 1.599,-0.335 2.2,-0.871 l 0.366,-0.313 a 1.813,1.813 0 0 1 2.354,-0.019 l 0.55,0.456 v -0.002 c 0.579,0.466 1.289,0.751 2.065,0.751 1.68,0 3.082,-1.29 3.408,-3.005 0.161,-0.427 0.457,-3.115 0.262,-3.858 z"
+     id="path4" />
+  <path
+     fill="#8000D7"
+     d="m 6.625,8.553 c -0.697,0 -1.317,0.291 -1.717,0.743 a 0.65,0.65 0 0 0 0,0.848 c 0.4,0.452 1.02,0.743 1.717,0.743 0.697,0 1.317,-0.291 1.717,-0.743 a 0.65,0.65 0 0 0 0,-0.848 C 7.942,8.844 7.322,8.553 6.625,8.553 Z"
+     id="path6"
+     style="fill:#345cc6;fill-opacity:1" />
+  <path
+     fill="#8000D7"
+     d="m 13.375,8.553 c -0.697,0 -1.317,0.291 -1.717,0.743 a 0.65,0.65 0 0 0 0,0.848 c 0.4,0.452 1.02,0.743 1.717,0.743 0.697,0 1.317,-0.291 1.717,-0.743 a 0.65,0.65 0 0 0 0,-0.848 c -0.4,-0.452 -1.02,-0.743 -1.717,-0.743 z"
+     id="path8"
+     style="fill:#345cc6;fill-opacity:1" />
+</svg>

--- a/theme/pages/privatebrowsing.css
+++ b/theme/pages/privatebrowsing.css
@@ -1,0 +1,10 @@
+/* about:privatebrowsing */
+
+@-moz-document url("about:privatebrowsing") {
+    html.private {
+	--in-content-page-background: var(--gnome-private-background) !important;
+    }
+    .info {
+    	background-image: url("../icons/indicator-private-browsing.svg") !important;
+    }
+}

--- a/theme/parts/searchbar.css
+++ b/theme/parts/searchbar.css
@@ -1,0 +1,11 @@
+/* Search bar */
+
+@namespace xul "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
+
+.searchbar-engine-one-off-item[selected] {
+	background-color: var(--button-active-bgcolor) !important;
+}
+
+.searchbar-engine-one-off-item {
+	background-color: transparent !important;
+}

--- a/userContent.css
+++ b/userContent.css
@@ -2,3 +2,4 @@
 @import "theme/colors/dark.css";
 
 @import "theme/pages/newtab.css";
+@import "theme/pages/privatebrowsing.css";


### PR DESCRIPTION
There was a small issue with picking the search engine using arrow keys from the search bar. The buttons did not highlight as they should in vanilla Firefox theme.
I've also changed how the private browsing new tab page looks, so it would suit the customized title bar better.