### PR TITLE
GNOME Web video player theme in Firefox

### DIFF
--- a/theme/parts/video-player.css
+++ b/theme/parts/video-player.css
@@ -1,0 +1,75 @@
+@namespace xul url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
+@namespace html url("http://www.w3.org/1999/xhtml");
+
+/** Video player **/
+
+.progressBar::-moz-progress-bar {
+	background-color: #fff !important;
+}
+
+.scrubber:hover::-moz-range-thumb,
+.volumeControl:hover::-moz-range-thumb {
+	background-color: #ccc !important;
+}
+
+.scrubber:active::-moz-range-thumb,
+.volumeControl:active::-moz-range-thumb {
+	background-color: #bbb !important;
+}
+
+.controlBar {
+	border-radius: 5px;
+	margin: auto;
+	margin-bottom: 5px;
+	width: 98.5%;
+	max-width: 800px;
+	height: 30px !important;
+	background-color: rgba(20,20,20,0.8) !important;
+}
+
+.controlBar > .button:enabled:hover {
+	fill: #ccc !important;
+}
+  
+.controlBar > .button:enabled:hover:active {
+	fill: #bbb !important;
+}
+
+.scrubberStack {
+	margin: 0 10px;
+}
+
+.playButton {
+	scale: 0.8;
+}
+  
+
+
+/** Vertical Volume Bar **/
+/* I'm to stupid to get this working. Wasn't able to set proper position relative to mute button */
+
+/* .muteButton:hover ~ .volumeStack{
+	margin-bottom: 129px !important;
+  }
+	.volumeStack:hover {
+	margin-bottom: 129px !important;
+  }
+  
+  .volumeStack {
+	transform: rotate(270deg);
+	max-height: 33px !important;
+	min-width: 100px !important;
+  position:absolute !important;
+  margin-bottom: -150px !important;
+	background-color: rgba(20,20,20,0.8) !important;
+	border-bottom-right-radius: 5px !important;
+	border-top-right-radius: 5px !important;
+	transition-property: margin-bottom;
+	transition-duration: 0.13s;
+	transition-timing-function: linear;
+  }
+  
+  .volumeControl{
+	  width: 92% !important;
+	  margin-left: 5px !important;
+} */

--- a/userContent.css
+++ b/userContent.css
@@ -2,4 +2,6 @@
 @import "theme/colors/dark.css";
 
 @import "theme/pages/newtab.css";
-@import "theme/pages/privatebrowsing.css"
+@import "theme/pages/privatebrowsing.css";
+
+@import "theme/parts/video-player.css";


### PR DESCRIPTION
I was trying to get the GNOME Web video player theme in Firefox and I think it turned out quite right. Sadly I wasn't able to get vertical volume bar to work correctly, mainly it positioning, but I think even without it theme still looks good. I've attached to the code commented out code to vertical volume bar if you want to try to do something with it.

Preview:
Gnome Web
![gnome_web](https://user-images.githubusercontent.com/49432482/176996644-c2e2d968-8eec-4632-9672-4b65bf001776.png)

Firefox - Before:
![firefox_before](https://user-images.githubusercontent.com/49432482/176996662-3f9a20a8-48de-424c-8669-9ad3b185bfff.png)

Firefox - After:
![firefox_after](https://user-images.githubusercontent.com/49432482/176996744-362ed982-62af-4465-bd13-60fcb96561f0.png)

