### PR TITLE
Fix fullscreen and improve CSD code

### DIFF
--- a/theme/parts/csd.css
+++ b/theme/parts/csd.css
@@ -11,30 +11,43 @@
 	border-radius: env(-moz-gtk-csd-titlebar-radius) env(-moz-gtk-csd-titlebar-radius) 0 0 !important;
 }
 
+
 /* Window buttons: at least 1 button */
 @media (-moz-gtk-csd-minimize-button), (-moz-gtk-csd-maximize-button), (-moz-gtk-csd-close-button) {
-	:root[tabsintitlebar]:not([inFullscreen]) #nav-bar {
-		padding-right: 50px !important;
+	:root {
+		--gnome-navbar-csd-offset: 50px;
 	}
 }
 /* Window buttons: at least 2 buttons */
 @media (-moz-gtk-csd-minimize-button) and (-moz-gtk-csd-maximize-button),
        (-moz-gtk-csd-minimize-button) and (-moz-gtk-csd-close-button),
        (-moz-gtk-csd-maximize-button) and (-moz-gtk-csd-close-button) {
-	:root[tabsintitlebar]:not([inFullscreen]) #nav-bar {
-		padding-right: 90px !important;
+	:root {
+		--gnome-navbar-csd-offset: 90px;
 	}
 }
 /* Window buttons: 3 buttons */
 @media (-moz-gtk-csd-minimize-button) and (-moz-gtk-csd-maximize-button) and (-moz-gtk-csd-close-button) {
-	:root[tabsintitlebar]:not([inFullscreen]) #nav-bar {
-		padding-right: 130px !important;
+	:root {
+		--gnome-navbar-csd-offset: 130px;
 	}
+}
+
+/* Right window buttons offset by button count */
+:root[tabsintitlebar]:not([inFullscreen]) #nav-bar {
+	padding-left: 3px !important;
+	padding-right: var(--gnome-navbar-csd-offset) !important;
+}
+/* Fullscreen headerbar padding for 1 button */
+:root[tabsintitlebar][inFullscreen] #nav-bar {
+	padding-right: 50px !important;
 }
 
 /* Left window buttons */
 @media (-moz-gtk-csd-reversed-placement) {
+	/* Window controls offset by button count */
 	:root[tabsintitlebar]:not([inFullscreen]) #nav-bar {
+		padding-left: var(--gnome-navbar-csd-offset) !important;
 		padding-right: 3px !important;
 	}
 	
@@ -43,39 +56,28 @@
 		left: 0;
 		right: auto !important;
 	}
-
-	/* Window controls: at least 1 button */
-	@media (-moz-gtk-csd-minimize-button), (-moz-gtk-csd-maximize-button), (-moz-gtk-csd-close-button) {
-		:root[tabsintitlebar]:not([inFullscreen]) #nav-bar {
-			padding-left: 50px !important;
-		}
+	
+	/* Fullscreen headerbar padding for 1 button */
+	:root[tabsintitlebar][inFullscreen] #nav-bar {
+		padding-left: 50px !important;
+		padding-right: 3px !important
 	}
-	/* Window controls: at least 2 buttons */
-	@media (-moz-gtk-csd-minimize-button) and (-moz-gtk-csd-maximize-button),
-				 (-moz-gtk-csd-minimize-button) and (-moz-gtk-csd-close-button),
-				 (-moz-gtk-csd-maximize-button) and (-moz-gtk-csd-close-button) {
-		:root[tabsintitlebar]:not([inFullscreen]) #nav-bar {
-			padding-left: 90px !important;
-		}
-	}
-	/* Window controls: 3 buttons */
-	@media (-moz-gtk-csd-minimize-button) and (-moz-gtk-csd-maximize-button) and (-moz-gtk-csd-close-button) {
-		:root[tabsintitlebar]:not([inFullscreen]) #nav-bar {
-			padding-left: 130px !important;
-		}
-	} 
-}
-
-/* Fullscreen headerbar padding for 1 button */
-:root[tabsintitlebar][inFullscreen] #nav-bar {
-	padding-right: 50px !important;
 }
 
 /* Remove close and minimize buttons from fullscreen buttons */
-:root[tabsintitlebar][inFullscreen] #window-controls #close-button,
-:root[tabsintitlebar][inFullscreen] #window-controls #minimize-button,
-:root[tabsintitlebar][inFullscreen] #titlebar .titlebar-buttonbox-container {
+:root[tabsintitlebar][inFullscreen] #titlebar .titlebar-buttonbox-container .titlebar-min,
+:root[tabsintitlebar][inFullscreen] #titlebar .titlebar-buttonbox-container .titlebar-close {
 	display: none !important;
+}
+
+/* Force the restore button to appear regardless of maximize button's status */
+:root[tabsintitlebar][inFullscreen] #titlebar .titlebar-buttonbox-container .titlebar-restore {
+	display: inherit !important;
+}
+
+/* Hide window controls when navbar is hidden */
+:root[tabsintitlebar][inFullscreen] #navigator-toolbox[style*='margin-top:'] #titlebar .titlebar-buttonbox-container {
+  top: -999px;
 }
 
 /* Remove tabsbar titlebar blank spaces */
@@ -100,11 +102,9 @@
 }
 
 /* Window buttons box */
-:root[tabsintitlebar] #titlebar .titlebar-buttonbox-container,
-:root[tabsintitlebar] #titlebar-buttonbox-container,
-:root[tabsintitlebar][inFullscreen] #window-controls {
+:root[tabsintitlebar] #titlebar .titlebar-buttonbox-container {
 	-moz-appearance: none !important;
-	padding: 6px 3px;
+	padding: 5px 3px;
 	position: absolute !important;	
 	right: 0;
 	top: 0;


### PR DESCRIPTION
Fullscreen mode is currently missing window controls if the maximize button is disabled (as GNOME does by default). There will be a blank space on the right of the navbar instead. This changes it to always show the restore button, which I believe was the intended behavior.

On top of this, I have refactored the code to detect the number and placement of window controls, using variables instead. This code is much cleaner, and has a side effect of now live-updating when the button count or position is changed.

I also adjusted a value by one pixel, because perfectionism.