### PR TITLE
Support for Snap versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ We also have the `beta` branch for fixes only aplicable to the current Firefox b
 	```sh
 	./scripts/install.sh # Standard
 	./scripts/install.sh -f ~/.var/app/org.mozilla.firefox/.mozilla/firefox # Flatpak
+	./scripts/install.sh -f ~/snap/firefox/common/.mozilla/firefox #Snap
 	```
 
 	##### Script options

--- a/scripts/auto-install.sh
+++ b/scripts/auto-install.sh
@@ -8,6 +8,7 @@ firefoxInstalationPaths=(
     ~/.var/app/org.mozilla.firefox/.mozilla/firefox
     ~/.librewolf
     ~/.var/app/io.gitlab.librewolf-community/.librewolf
+    ~/snap/firefox/common/.mozilla/firefox
 )
 
 currentTheme=$(gsettings get org.gnome.desktop.interface gtk-theme ) || currentTheme=""


### PR DESCRIPTION
I have added the snap folder in the `auto-install.sh` script. Now people in ubuntu with default firefox snap can easily install the theme. Also added the easy snap support.