### PR TITLE
Fix fullscreen (again)

### DIFF
--- a/theme/parts/csd.css
+++ b/theme/parts/csd.css
@@ -11,7 +11,6 @@
 	border-radius: env(-moz-gtk-csd-titlebar-radius) env(-moz-gtk-csd-titlebar-radius) 0 0 !important;
 }
 
-
 /* Window buttons: at least 1 button */
 @media (-moz-gtk-csd-minimize-button), (-moz-gtk-csd-maximize-button), (-moz-gtk-csd-close-button) {
 	:root {
@@ -71,6 +70,9 @@
 }
 
 /* Force the restore button to appear regardless of maximize button's status */
+:root[tabsintitlebar][inFullscreen] #titlebar .titlebar-buttonbox-container {
+  visibility: visible !important;
+}
 :root[tabsintitlebar][inFullscreen] #titlebar .titlebar-buttonbox-container .titlebar-restore {
 	display: inherit !important;
 }


### PR DESCRIPTION
Looks like the restore button is still hiding, due to the whole controls container trying to hide itself. Very small change to fix that. I also noticed I accidentally added a blank line in my previous PR, so I undid that.