### PR TITLE
Add gnomeTheme.tabsAsHeaderbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ Optional features can be enabled by creating new `boolean` preferences in `about
 
 	> **Note:** This feature is BUGGED. It can activate the button with unpleasant behavior.
 
+- **Tabs as headerbar** `gnomeTheme.tabsAsHeaderbar`
+
+	Place the tabs on the top of the window, and use the tabs bar to hold the window controls, like Firefox's standard tab bar.
+	
+	> **Note:** Enabling with `gnomeTheme.hideSingleTab` will replace the single tab with a title bar.
+
 ### Extensions support
 
 We also have optional features to enable support for some Firefox extensions.

--- a/theme/parts/tabsbar.css
+++ b/theme/parts/tabsbar.css
@@ -531,8 +531,7 @@ tab {
 	}
 	
 	/* Remove nav-bar rounding and padding */
-	:root[tabsintitlebar]:not([inFullscreen]) #nav-bar,
-	:root[tabsintitlebar][inFullscreen] #nav-bar {
+	:root[tabsintitlebar][sizemode="normal"]:not([gtktiledwindow="true"]) #nav-bar {
 		border-radius: 0 !important;
 		padding-left: 3px !important;
 		padding-right: 3px !important;

--- a/theme/parts/tabsbar.css
+++ b/theme/parts/tabsbar.css
@@ -510,3 +510,84 @@ tab {
 		margin-right: -16px;
 	}
 }
+
+/* OPTIONAL: Use tabs as headerbar */
+@supports -moz-bool-pref("gnomeTheme.tabsAsHeaderbar") {
+	/* Rearrange bars */
+	#navigator-toolbox #titlebar {
+		-moz-box-ordinal-group: 0;
+	}
+	#navigator-toolbox #titlebar #TabsToolbar {
+		-moz-box-ordinal-group: 0;
+	}
+	#navigator-toolbox #titlebar #toolbar-menubar {
+		-moz-box-ordinal-group: 1;
+	}
+	#navigator-toolbox #nav-bar {
+		-moz-box-ordinal-group: 1;
+	}
+	#navigator-toolbox #PersonalToolbar {
+		-moz-box-ordinal-group: 2;
+	}
+	
+	/* Remove nav-bar rounding and padding */
+	:root[tabsintitlebar]:not([inFullscreen]) #nav-bar,
+	:root[tabsintitlebar][inFullscreen] #nav-bar {
+		border-radius: 0 !important;
+		padding-left: 3px !important;
+		padding-right: 3px !important;
+	}
+	
+	/* Round and pad tab-bar */
+	:root[tabsintitlebar] #TabsToolbar {
+		border-radius: env(-moz-gtk-csd-titlebar-radius) env(-moz-gtk-csd-titlebar-radius) 0 0 !important
+	}
+	:root[tabsintitlebar] #TabsToolbar .toolbar-items {
+		padding: 0 46px;
+	}
+	
+	/* Hide duplicate window controls from menubar */
+	:root[tabsintitlebar] #toolbar-menubar .titlebar-buttonbox-container {
+		display: none !important;
+	}
+	
+	/* Force displaying controls in tab-bar */
+	:root[tabsintitlebar] #TabsToolbar .titlebar-buttonbox-container:not(#hack) {
+		display: -moz-box !important;
+		position: static !important;
+		visibility: visible !important;
+	}
+	
+	/* Blend single tab into whole bar */
+	@supports -moz-bool-pref("gnomeTheme.hideSingleTab") {
+		#tabbrowser-tabs tab[first-visible-tab="true"][last-visible-tab="true"]:not([pinned]),
+		#tabbrowser-tabs tab[first-visible-tab="true"][last-visible-tab="true"]:not([pinned]) ~ toolbarbutton,
+		#tabbrowser-tabs tab[first-visible-tab="true"][last-visible-tab="true"]:not([pinned]) ~ #tabbrowser-arrowscrollbox-periphery {
+			visibility: visible;
+		}
+		#tabbrowser-tabs tab[first-visible-tab="true"][last-visible-tab="true"]:not([pinned]) {
+			-moz-window-dragging: drag;
+		}
+		#tabbrowser-tabs tab[first-visible-tab="true"][last-visible-tab="true"]:not([pinned]) .tab-background {
+			display: none !important
+		}
+		#tabbrowser-tabs tab[first-visible-tab="true"][last-visible-tab="true"]:not([pinned]) .tab-close-button {
+			visibility: hidden !important;
+			opacity: 0 !important;
+		}
+		#tabbrowser-tabs tab[first-visible-tab="true"][last-visible-tab="true"]:not([pinned]) .tab-content::before {
+			--gnome-tabbar-tab-close-overlay-bg: unset !important;
+		}
+		#tabbrowser-tabs tab[first-visible-tab="true"][last-visible-tab="true"]:not([pinned]) .tab-labelk-container[textoverflow="true"] {
+			margin-right: -16px;
+		}
+		/* Override normal width tabs */
+		@supports -moz-bool-pref("gnomeTheme.normalWidthTabs") {
+			#tabbrowser-tabs tab[first-visible-tab="true"][last-visible-tab="true"]:not([pinned]):not([style^="max-width"]),
+			#tabbrowser-tabs tab[first-visible-tab="true"][last-visible-tab="true"][style^="max-width: 100px !important;"]:not([pinned]) {
+				max-width: 100% !important;
+				--tab-min-width: 131px !important;
+			}
+		}
+	}
+}


### PR DESCRIPTION
This adds an optional feature to place the tabs on the top of the window, and use the tabs bar to hold the window controls. Padding is added to both sides of the tabs, to give plenty of space to drag the window around.

![Preview image of the optional feature](https://user-images.githubusercontent.com/35016761/197295828-95abe19b-4f72-48b4-a1ee-67f1f09dfa72.png)

When `gnomeTheme.hideSingleTab` is also enabled, rather than hiding the tab completely, it will make the tab blend into the rest of the bar, and allow dragging the window from it, emulating a simple title bar. Furthermore, if `gnomeTheme.normalWidthTabs` is enabled alongside both of these, it will be disabled when there is only one tab.

Resolves #328 