### PR TITLE
Fix nav-bar padding with tabsAsHeaderbar

### DIFF
--- a/theme/parts/tabsbar.css
+++ b/theme/parts/tabsbar.css
@@ -533,9 +533,11 @@ tab {
 	}
 	
 	/* Remove nav-bar rounding and padding */
+	:root[tabsintitlebar][sizemode="normal"]:not([gtktiledwindow="true"]) #nav-bar { 
+		border-radius: 0 !important; 
+	 } 
 	:root[tabsintitlebar]:not([inFullscreen]) #nav-bar,
 	:root[tabsintitlebar][inFullscreen] #nav-bar {
-		border-radius: 0 !important;
 		padding-left: 3px !important;
 		padding-right: 3px !important;
 	}

--- a/theme/parts/tabsbar.css
+++ b/theme/parts/tabsbar.css
@@ -533,7 +533,8 @@ tab {
 	}
 	
 	/* Remove nav-bar rounding and padding */
-	:root[tabsintitlebar][sizemode="normal"]:not([gtktiledwindow="true"]) #nav-bar {
+	:root[tabsintitlebar]:not([inFullscreen]) #nav-bar,
+	:root[tabsintitlebar][inFullscreen] #nav-bar {
 		border-radius: 0 !important;
 		padding-left: 3px !important;
 		padding-right: 3px !important;


### PR DESCRIPTION
Fixes #494. I'm not sure why I put `[sizemode="normal"]:not([gtktiledwindow="true"])` there, but it seems irrelevant.