### PR TITLE
add failproof

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,15 +26,15 @@ done
 function saveProfile(){
 	local PROFILE_PATH="$1"
 
-	cd "$FIREFOXFOLDER/$PROFILE_PATH" || echo "FAIL, Firefox profile path was not found." && exit 1
-	echo "Installing theme in $PWD"
+	cd "$FIREFOXFOLDER/$PROFILE_PATH" || { echo "FAIL, Firefox profile path was not found."; exit 1; }
+	echo "Installing theme in $PWD" >$(tty)
 	# Create a chrome directory if it doesn't exist.
 	mkdir -p chrome
-	cd chrome || echo "FAIL, couldn't create chrome dir in $PWD, please check if there's something else named 'chrome'." && exit 1
+	cd chrome || { echo "FAIL, couldn't create chrome dir in $PWD, please check if there's something else named 'chrome'."; exit 1; }
 
 	# Copy theme repo inside
-	echo "Copying repo in $PWD"
-	cp -fR "$THEMEDIRECTORY" "$PWD" || echo "FAIL, couldn't copy to $PWD/chrome, please check if there's something named 'chrome', that is not a dir." && exit 1
+	echo "Copying repo in $PWD" >&2
+	cp -fR "$THEMEDIRECTORY" "$PWD" || { echo "FAIL, couldn't copy to $PWD/chrome, please check if there's something named 'chrome', that is not a dir."; exit 1; }
 
 	# Create single-line user CSS files if non-existent or empty.
 	if [ -s userChrome.css ]; then
@@ -49,9 +49,9 @@ function saveProfile(){
 	sed -i '1s/^/@import "firefox-gnome-theme\/userChrome.css";\n/' userChrome.css
 
 	if [ "$THEME" = "DEFAULT" ]; then
-		echo "No theme set, using default adwaita."
+		echo "No theme set, using default adwaita." >&2
 	else
-		echo "Setting $THEME theme."
+		echo "Setting $THEME theme." >&2
 		echo "@import \"firefox-gnome-theme\/theme/colors/light-$THEME.css\";" >> userChrome.css
 		echo "@import \"firefox-gnome-theme\/theme/colors/dark-$THEME.css\";" >> userChrome.css
 	fi
@@ -69,7 +69,7 @@ function saveProfile(){
 	sed -i '1s/^/@import "firefox-gnome-theme\/userContent.css";\n/' userContent.css
 
 	if [ "$THEME" = "DEFAULT" ]; then
-		echo "No theme set, using default adwaita."
+		echo "No theme set, using default adwaita." >&2
 	else
 		echo "Setting $THEME theme."
 		echo "@import \"firefox-gnome-theme\/theme/colors/light-$THEME.css\";" >> userContent.css
@@ -79,10 +79,10 @@ function saveProfile(){
 	cd ..
 
 	# Symlink user.js to firefox-gnome-theme one.
-	echo "Set configuration user.js file"
+	echo "Set configuration user.js file" >&2
 	ln -is chrome/firefox-gnome-theme/configuration/user.js user.js
 
-	echo "Done."
+	echo "Done." >&2
 	cd ..
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set +vux
-
 THEMEDIRECTORY=$(cd "$(dirname $0)" && cd .. && pwd)
 FIREFOXFOLDER=~/.mozilla/firefox
 PROFILENAME=""
@@ -28,15 +26,15 @@ done
 function saveProfile(){
 	local PROFILE_PATH="$1"
 
-	cd "$FIREFOXFOLDER/$PROFILE_PATH" || echo "FAIL, Firefox profile path was not found." && exit
+	cd "$FIREFOXFOLDER/$PROFILE_PATH" || echo "FAIL, Firefox profile path was not found." && exit 1
 	echo "Installing theme in $PWD"
 	# Create a chrome directory if it doesn't exist.
 	mkdir -p chrome
-	cd chrome || echo "FAIL, couldn't create chrome dir in $PWD, please check if there's something else named 'chrome'." && exit
+	cd chrome || echo "FAIL, couldn't create chrome dir in $PWD, please check if there's something else named 'chrome'." && exit 1
 
 	# Copy theme repo inside
 	echo "Copying repo in $PWD"
-	cp -fR "$THEMEDIRECTORY" "$PWD" || echo "FAIL, couldn't copy to $PWD/chrome, please check if there's something named 'chrome', that is not a dir." && exit
+	cp -fR "$THEMEDIRECTORY" "$PWD" || echo "FAIL, couldn't copy to $PWD/chrome, please check if there's something named 'chrome', that is not a dir." && exit 1
 
 	# Create single-line user CSS files if non-existent or empty.
 	if [ -s userChrome.css ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
+set +vux
+
 THEMEDIRECTORY=$(cd "$(dirname $0)" && cd .. && pwd)
 FIREFOXFOLDER=~/.mozilla/firefox
 PROFILENAME=""
-THEME=DEFAULT
+THEME="DEFAULT"
 
 
 # Get options.
@@ -26,15 +28,15 @@ done
 function saveProfile(){
 	local PROFILE_PATH="$1"
 
-	cd "$FIREFOXFOLDER/$PROFILE_PATH" || echo "FAIL, Firefox profile path was not found" && exit
+	cd "$FIREFOXFOLDER/$PROFILE_PATH" || echo "FAIL, Firefox profile path was not found." && exit
 	echo "Installing theme in $PWD"
 	# Create a chrome directory if it doesn't exist.
 	mkdir -p chrome
-	cd chrome || echo "FAIL, couldn't create chrome dir in $PWD, please check if there's something else named 'chrome'" && exit
+	cd chrome || echo "FAIL, couldn't create chrome dir in $PWD, please check if there's something else named 'chrome'." && exit
 
 	# Copy theme repo inside
 	echo "Copying repo in $PWD"
-	cp -fR "$THEMEDIRECTORY" "$PWD" || echo "FAIL, couldn't copy to $PWD/chrome, please check if there's something named 'chrome', that is not a dir" && exit
+	cp -fR "$THEMEDIRECTORY" "$PWD" || echo "FAIL, couldn't copy to $PWD/chrome, please check if there's something named 'chrome', that is not a dir." && exit
 
 	# Create single-line user CSS files if non-existent or empty.
 	if [ -s userChrome.css ]; then
@@ -88,10 +90,10 @@ function saveProfile(){
 
 PROFILES_FILE="${FIREFOXFOLDER}/profiles.ini"
 if [ ! -f "${PROFILES_FILE}" ]; then
-	>&2 echo "FAIL, please check Firefox installation, unable to find profile.ini at ${FIREFOXFOLDER}"
+	>&2 echo "FAIL, please check Firefox installation, unable to find 'profile.ini' at ${FIREFOXFOLDER}."
 	exit 1
 fi
-echo "Profiles file found"
+echo "'profiles.ini' found in ${FIREFOXFOLDER}"
 
 PROFILES_PATHS=($(grep -E "^Path=" "${PROFILES_FILE}" | tr -d '\n' | sed -e 's/\s\+/SPACECHARACTER/g' | sed 's/Path=/::/g' )) 
 PROFILES_PATHS+=::
@@ -99,10 +101,10 @@ PROFILES_PATHS+=::
 PROFILES_ARRAY=()
 if [ "${PROFILENAME}" != "" ];
 	then
-		echo "Using ${PROFILENAME} theme"
+		echo "Using ${PROFILENAME} profile"
 		PROFILES_ARRAY+=${PROFILENAME}
 else
-	echo "Finding all avaliable themes";
+	echo "Finding all avaliable profiles";
 	while [[ "$PROFILES_PATHS" ]]; do
 		PROFILES_ARRAY+=( "${PROFILES_PATHS%%::*}" )
 		PROFILES_PATHS=${PROFILES_PATHS#*::}
@@ -112,14 +114,14 @@ fi
 
 
 if [ ${#PROFILES_ARRAY[@]} -eq 0 ]; then
-	echo "No Profiles found on $PROFILES_FILE";
+	echo "FAIL, no Firefox profiles found in $PROFILES_FILE".;
 
 else
 	for i in "${PROFILES_ARRAY[@]}"
 	do
 		if [[ -n "$i" ]];
 		then
-			echo "Installing Theme on $(sed 's/SPACECHARACTER/ /g' <<< $i)" ;
+			echo "Installing ${THEME} theme for $(sed 's/SPACECHARACTER/ /g' <<< $i) profile.";
 			saveProfile "$(sed 's/SPACECHARACTER/ /g' <<< $i)"
 		fi;
 	

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,15 +26,15 @@ done
 function saveProfile(){
 	local PROFILE_PATH="$1"
 
-	cd "$FIREFOXFOLDER/$PROFILE_PATH" || exit
+	cd "$FIREFOXFOLDER/$PROFILE_PATH" || echo "FAIL, Firefox profile path was not found" && exit
 	echo "Installing theme in $PWD"
 	# Create a chrome directory if it doesn't exist.
 	mkdir -p chrome
-	cd chrome || exit
+	cd chrome || echo "FAIL, couldn't create chrome dir in $PWD, please check if there's something else named 'chrome'" && exit
 
 	# Copy theme repo inside
 	echo "Copying repo in $PWD"
-	cp -fR "$THEMEDIRECTORY" "$PWD"
+	cp -fR "$THEMEDIRECTORY" "$PWD" || echo "FAIL, couldn't copy to $PWD/chrome, please check if there's something named 'chrome', that is not a dir" && exit
 
 	# Create single-line user CSS files if non-existent or empty.
 	if [ -s userChrome.css ]; then


### PR DESCRIPTION
Fixed:
https://www.shellcheck.net/wiki/SC2164 because I've had a symlink instead of `[ff_profile]/chrome` and it failed with:
```bash
cp: cannot overwrite non-directory '/home/[profile]/.mozilla/firefox/[ff_profile]/chrome/firefox-gnome-theme' with directory '/tmp/tmp.Rc3bJsmxw7/firefox-gnome-theme'
```
https://www.shellcheck.net/wiki/SC2220
https://www.shellcheck.net/wiki/SC2046
https://www.shellcheck.net/wiki/SC2094

There are still alerts:
https://www.shellcheck.net/wiki/SC2207
https://www.shellcheck.net/wiki/SC2001
https://www.shellcheck.net/wiki/SC2179