### PR TITLE
CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Smoke test
     steps:
-      - uses: actions/checkout@v3
-
-      - run: |
+      - name: Setup 1 - Install Firefox.deb and create a profile
+        run: |
           sudo add-apt-repository ppa:mozillateam/ppa
           echo '
           Package: *
@@ -19,5 +18,21 @@ jobs:
           sudo apt install firefox
           firefox --headless --createprofile test
 
-      - name: Test ./scripts/install.sh
-        run: ./scripts/install.sh
+      - name: Test 1 - Run a web installer as in README
+
+      - run: curl -s -o- https://raw.githubusercontent.com/rafaelmardojai/firefox-gnome-theme/master/scripts/install-by-curl.sh | bash
+
+      - name: Teardown 1
+        run: rm -rf ls ~/.mozilla/firefox/
+
+
+      - name: Setup 2 - Install Firefox.deb and create a profile
+
+      - name: Test 2 - Run a regular installer
+        uses: actions/checkout@v3
+
+      - run: ./scripts/install.sh
+
+      - name: Teardown 2
+        run: rm -rf ls ~/.mozilla/firefox/
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container: docker.io/linuxserver/firefox:latest
+    name: Smoke test
+    steps:
+      - uses: actions/checkout@v3
+
+      - run: firefox --headless --createprofile test
+
+      - name: Test ./install.sh
+        run: ./install.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,21 +3,13 @@ on: [push]
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: docker.io/linuxserver/firefox:latest
     name: Smoke test
     steps:
-      - name: Work around a weird checkout action 'node' placement
-        # details https://github.com/TriplEight/firefox-gnome-theme/actions/runs/3735689911/jobs/6339214781
-        run: |
-          echo "Checking for a usable node in /__e/node"
-           for f in /__e/node*/bin/node; do
-               echo "Testing: $f --version";
-               $f --version || echo "$f does not work, exit status: $?"
-          done
-
       - uses: actions/checkout@v3
 
-      - run: firefox --headless --createprofile test
+      - run: |
+        apt update && apt install firefox
+        firefox --headless --createprofile test
 
       - name: Test ./scripts/install.sh
         run: ./scripts/install.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,16 @@ jobs:
       - uses: actions/checkout@v3
 
       - run: |
-        apt update && apt install firefox
-        firefox --headless --createprofile test
+          sudo add-apt-repository ppa:mozillateam/ppa
+          echo '
+          Package: *
+          Pin: release o=LP-PPA-mozillateam
+          Pin-Priority: 1001
+          ' | sudo tee /etc/apt/preferences.d/mozilla-firefox
+          echo 'Unattended-Upgrade::Allowed-Origins:: "LP-PPA-mozillateam:${distro_codename}";' | sudo tee /etc/apt/apt.conf.d/51unattended-upgrades-firefox
+          sudo apt update
+          sudo apt install firefox
+          firefox --headless --createprofile test
 
       - name: Test ./scripts/install.sh
         run: ./scripts/install.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,5 +10,5 @@ jobs:
 
       - run: firefox --headless --createprofile test
 
-      - name: Test ./install.sh
-        run: ./install.sh
+      - name: Test ./scripts/install.sh
+        run: ./scripts/install.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Smoke test
     steps:
-      - name: Setup 1 - Install Firefox.deb and create a profile
+      - name: Setup - Install Firefox.deb
         run: |
           sudo add-apt-repository ppa:mozillateam/ppa
           echo '
@@ -16,22 +16,25 @@ jobs:
           echo 'Unattended-Upgrade::Allowed-Origins:: "LP-PPA-mozillateam:${distro_codename}";' | sudo tee /etc/apt/apt.conf.d/51unattended-upgrades-firefox
           sudo apt update
           sudo apt install firefox
+      
+      - name: Setup 1 - create a Firefox profile
           firefox --headless --createprofile test
 
       - name: Test 1 - Run a web installer as in README
-
-      - run: curl -s -o- https://raw.githubusercontent.com/rafaelmardojai/firefox-gnome-theme/master/scripts/install-by-curl.sh | bash
+        run: curl -s -o- https://raw.githubusercontent.com/rafaelmardojai/firefox-gnome-theme/master/scripts/install-by-curl.sh | bash
 
       - name: Teardown 1
         run: rm -rf ls ~/.mozilla/firefox/
 
 
-      - name: Setup 2 - Install Firefox.deb and create a profile
+      - name: Setup 2 - create a new Firefox profile
+        run: firefox --headless --createprofile test
 
-      - name: Test 2 - Run a regular installer
+      - name: Setup 2 - checkout the repo
         uses: actions/checkout@v3
 
-      - run: ./scripts/install.sh
+      - name: Test 2 - Run a regular installer
+        run: ./scripts/install.sh
 
       - name: Teardown 2
         run: rm -rf ls ~/.mozilla/firefox/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,11 @@ jobs:
       - name: Work around a weird checkout action 'node' placement
         # details https://github.com/TriplEight/firefox-gnome-theme/actions/runs/3735689911/jobs/6339214781
         run: |
+          echo "Checking for a usable node in /__e/node"
+           for f in /__e/node*/bin/node; do
+               echo "Testing: $f --version";
+               $f --version || echo "$f does not work, exit status: $?"
+          done
           mkdir -p /__e/node16/bin/
           ln -s $(which node) /__e/node16/bin/node
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,12 @@ jobs:
     container: docker.io/linuxserver/firefox:latest
     name: Smoke test
     steps:
+      - name: Work around a weird checkout action 'node' placement
+        # details https://github.com/TriplEight/firefox-gnome-theme/actions/runs/3735689911/jobs/6339214781
+        run: |
+          mkdir -p /__e/node16/bin/
+          ln -s $(which node) /__e/node16/bin/node
+
       - uses: actions/checkout@v3
 
       - run: firefox --headless --createprofile test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,6 @@ jobs:
                echo "Testing: $f --version";
                $f --version || echo "$f does not work, exit status: $?"
           done
-          mkdir -p /__e/node16/bin/
-          ln -s $(which node) /__e/node16/bin/node
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           sudo apt install firefox
       
       - name: Setup 1 - create a Firefox profile
-          firefox --headless --createprofile test
+        run: firefox --headless --createprofile test
 
       - name: Test 1 - Run a web installer as in README
         run: curl -s -o- https://raw.githubusercontent.com/rafaelmardojai/firefox-gnome-theme/master/scripts/install-by-curl.sh | bash


### PR DESCRIPTION
CI with smoke tests.
Unfortunately, couldn't think of a faster way to setup Firefox.
Teh Setup is some 30+ sec. This is why I'm lining up the tests: doing a Teardown after each - to not to have to reinstall it ever again.

Please consider using this Setup (create firefox profile) - Teardown (remove firefox profile) method for the upcoming tests.

Also,  if you're enabling Github Actions for the repo, in order for it to be useful, you should protect the `master` branch and assign this test as **required** in the branch protection rules.