### PR TITLE
Fix tab-bar border-radius when using tabsAsHeaderbar

### DIFF
--- a/theme/parts/tabsbar.css
+++ b/theme/parts/tabsbar.css
@@ -543,7 +543,7 @@ tab {
 	}
 	
 	/* Round and pad tab-bar */
-	:root[tabsintitlebar] #TabsToolbar {
+	:root[tabsintitlebar][sizemode="normal"]:not([gtktiledwindow="true"]) #TabsToolbar {
 		border-radius: env(-moz-gtk-csd-titlebar-radius) env(-moz-gtk-csd-titlebar-radius) 0 0 !important
 	}
 	:root[tabsintitlebar] #TabsToolbar .toolbar-items {


### PR DESCRIPTION
IDK if you see it or not but there's a tiny border bug when using tabsAsHeaderbar.
Note: I changed the headerbar color just to illustrate the fix.

BEFORE:
![Screenshot from 2023-02-08 18-23-12-modified](https://user-images.githubusercontent.com/43321350/217543089-dc93bbe9-ef60-4abf-b55a-71e5128e8e7e.png)

AFTER:
![Screenshot from 2023-02-08 18-23-38](https://user-images.githubusercontent.com/43321350/217539367-8187e492-f2a0-4e82-a0fd-ecd241b4f4fc.png)

