### PR TITLE
PR to Disable Tab Collapsing of the extension with a flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ We also have optional features to enable support for some Firefox extensions.
 	Enable the vertical tab trough the extension : [Tab Center Reborn](https://addons.mozilla.org/en-US/firefox/addon/tabcenter-reborn/).
 
 	> **Note:** You also need to copy the contents of the file `configuration/extensions/tab-center-reborn.css` into the settings page of Tabcenter-reborn..\
-	> **Note2:** You can also maintain the vertical tab always open with `gnomeTheme.extensions.tabCenterReborn-always-open`
+	> **Note2:** You can also maintain the vertical tab always open with `gnomeTheme.extensions.tabCenterReborn.alwaysOpen`
 	
 ## Known bugs
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,8 @@ We also have optional features to enable support for some Firefox extensions.
 
 	Enable the vertical tab trough the extension : [Tab Center Reborn](https://addons.mozilla.org/en-US/firefox/addon/tabcenter-reborn/).
 
-	> **Note:** You also need to copy the contents of the file `configuration/extensions/tab-center-reborn.css` into the settings page of Tabcenter-reborn..
+	> **Note:** You also need to copy the contents of the file `configuration/extensions/tab-center-reborn.css` into the settings page of Tabcenter-reborn..\
+	> **Note2:** You can also maintain the vertical tab always open with `gnomeTheme.extensions.tabCenterReborn-always-open`
 	
 ## Known bugs
 

--- a/theme/extensions/tab-center-reborn.css
+++ b/theme/extensions/tab-center-reborn.css
@@ -117,3 +117,14 @@
         }
     }
 }
+
+@supports -moz-bool-pref("gnomeTheme.extensions.tabCenterReborn-always-open") {
+    #sidebar-box[sidebarcommand*="tabcenter"] #sidebar,
+    #sidebar-box[sidebarcommand*="tabcenter"] {
+        min-width: 10vw !important;
+        width: 30vw !important;
+        max-width: 200px !important;
+        z-index: 1 !important;
+        transition: all var(--transition-time) ease var(--delay);
+    }
+}

--- a/theme/extensions/tab-center-reborn.css
+++ b/theme/extensions/tab-center-reborn.css
@@ -39,6 +39,7 @@
         min-width: 48px;
         max-width: 48px;
         overflow: hidden;
+        
         border-right: 1px solid var(--sidebar-border-color);
         z-index: 1;
         top: 0;
@@ -126,5 +127,10 @@
         max-width: 200px !important;
         z-index: 1 !important;
         transition: all var(--transition-time) ease var(--delay);
+    }
+    
+    #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) {
+        position: relative;
+        margin-right: -50px;
     }
 }

--- a/theme/extensions/tab-center-reborn.css
+++ b/theme/extensions/tab-center-reborn.css
@@ -119,12 +119,12 @@
     }
 }
 
-@supports -moz-bool-pref("gnomeTheme.extensions.tabCenterReborn-always-open") {
+@supports -moz-bool-pref("gnomeTheme.extensions.tabCenterReborn.alwaysOpen") {
     #sidebar-box[sidebarcommand*="tabcenter"] #sidebar,
     #sidebar-box[sidebarcommand*="tabcenter"] {
         min-width: 10vw !important;
         width: 30vw !important;
-        max-width: 200px !important;
+        max-width: 250px !important;
         z-index: 1 !important;
         transition: all var(--transition-time) ease var(--delay);
     }
@@ -132,5 +132,12 @@
     #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) {
         position: relative;
         margin-right: -50px;
+    }
+    
+    @media (width >= 1200px) {
+        #sidebar-box[sidebarcommand*="tabcenter"]:hover #sidebar,
+        #sidebar-box[sidebarcommand*="tabcenter"]:hover {
+            max-width: 250px !important;
+        }
     }
 }


### PR DESCRIPTION
This fix implement a flag to fix this issue : https://github.com/rafaelmardojai/firefox-gnome-theme/issues/587
and modify the readme to put the flag into the config.