### PR TITLE
Update tab-center-reborn.css

### DIFF
--- a/configuration/extensions/tab-center-reborn.css
+++ b/configuration/extensions/tab-center-reborn.css
@@ -74,12 +74,7 @@ body {
 }
 
 #newtab {
-    flex-grow: 1;
-    margin-right: 2px;
-    margin-left: 2px;
-    padding-left: 9px;
-    min-width: 36px;
-    width: 100%;
+    display:none;
 }
 
 .tab,


### PR DESCRIPTION
Remove duplicate newtab button from the extension (double clic remain active)

@rafaelmardojai I do propose it to match more the gnome theme by only showing the tab vertically and so push user to use the newtab button of your theme.

Since it's a change into the config of the extension the user must manually change it if he want this change to apply (so it's an opt-in change).