### PR TITLE
Hide fullscreen window control when in DOM fullscreen

### DIFF
--- a/theme/parts/csd.css
+++ b/theme/parts/csd.css
@@ -70,7 +70,7 @@
 }
 
 /* Force the restore button to appear regardless of maximize button's status */
-:root[tabsintitlebar][inFullscreen] #titlebar .titlebar-buttonbox-container {
+:root[tabsintitlebar][inFullscreen]:not([inDOMFullscreen]) #titlebar .titlebar-buttonbox-container {
   visibility: visible !important;
 }
 :root[tabsintitlebar][inFullscreen]:not([inDOMFullscreen]) #titlebar .titlebar-buttonbox-container .titlebar-restore {


### PR DESCRIPTION
Resolves #560, which I have been able to reproduce. I have been running on this patch for the past few months without any issues.

Window controls are now hidden in DOM fullscreen (i.e. clicking fullscreen on YouTube). Normal F11 fullscreen still behaves as expected, with the restore button present on the navbar when it is shown.