### PR TITLE
Fix incognito eye icon overflowing

### DIFF
--- a/theme/parts/headerbar-private-window.css
+++ b/theme/parts/headerbar-private-window.css
@@ -25,7 +25,10 @@
 /* Add private window headerbar indicator */
 :root[privatebrowsingmode="temporary"] #nav-bar toolbarspring:first-of-type:before {
 	background: url("../icons/eye-not-looking-symbolic.svg") no-repeat;
-	background-size: 64px 64px;
+	background-size: contain;
+	padding: 4px;
+  	box-sizing: border-box;
+ 	background-origin: content-box;
 	content: "";
 	display: block;	
 	position: absolute;


### PR DESCRIPTION
Before: 
![Screenshot from 2023-06-24 23-37-06](https://github.com/rafaelmardojai/firefox-gnome-theme/assets/74397286/65df8a8f-5224-43e1-aeab-f173bfc66034)

After: 
![Screenshot from 2023-06-24 23-37-30](https://github.com/rafaelmardojai/firefox-gnome-theme/assets/74397286/8d72011b-c9f1-4ce1-bb67-28aa6bb14727)