### PR TITLE
Hide fullscreen button in DOM fullscreen when using tabsAsHeaderbar

### DIFF
--- a/theme/parts/tabsbar.css
+++ b/theme/parts/tabsbar.css
@@ -582,7 +582,7 @@ tab {
 	}
 	
 	/* Force displaying controls in tab-bar */
-	:root[tabsintitlebar] #TabsToolbar .titlebar-buttonbox-container:not(#hack) {
+	:root[tabsintitlebar]:not([inDOMFullscreen]) #TabsToolbar .titlebar-buttonbox-container:not(#hack) {
 		display: flex !important;
 		position: static !important;
 		visibility: visible !important;


### PR DESCRIPTION
Follow-up to #618, this removes the exit fullscreen button in the top corner of things like YouTube videos for those with the `tabsAsHeaderbar` setting active.

Should resolve the discussion in #618.