### PR TITLE
system-icons: Fix new tab icon in headerbar

### DIFF
--- a/theme/system-icons.css
+++ b/theme/system-icons.css
@@ -70,6 +70,7 @@
 		list-style-image: url("moz-icon://stock/open-menu-symbolic?size=dialog") !important;
 	}
 	/* New tab button */
+	#new-tab-button .toolbarbutton-icon,
 	#tabs-newtab-button  .toolbarbutton-icon,
 	#TabsToolbar #new-tab-button .toolbarbutton-icon {
 		filter: var(--gnome-icons-hack-filter);


### PR DESCRIPTION
Commit f7aeedf515c4f3891a8d922f1869e960cab5f8fe broke the new tab system icon theming for me (I have it in the header bar next to the refresh button). This adds back the CSS removed in that commit and fixes the issue.