### PR TITLE
theme: Update light theme to match Epiphany from GNOME 45

### DIFF
--- a/theme/colors/light.css
+++ b/theme/colors/light.css
@@ -82,7 +82,7 @@
 	--gnome-menu-separator-color: var(--gnome-border-color);
 	
 	/* Header bar */
-	--gnome-headerbar-background: #ebebeb;
+	--gnome-headerbar-background: #ffffff;
 	--gnome-headerbar-shade-color: rgba(0, 0, 0, 0.07);
 
 	/* Toolbars */
@@ -117,10 +117,10 @@
 	/* Tabs */
 	--gnome-tabbar-background: var(--gnome-headerbar-background);
 	--gnome-tabbar-tab-separator-color: var(--gnome-border-color);
-	--gnome-tabbar-tab-hover-background: #dedede; /* Hardcoded color */
-	--gnome-tabbar-tab-active-background: #d9d9d9; /* Hardcoded color */
+	--gnome-tabbar-tab-hover-background: #f1f1f1; /* Hardcoded color */
+	--gnome-tabbar-tab-active-background: #ebebeb; /* Hardcoded color */
 	--gnome-tabbar-tab-active-background-contrast: #c0c0c0; /* Hardcoded color */
-	--gnome-tabbar-tab-active-hover-background: #d2d2d2; /* Hardcoded color */
+	--gnome-tabbar-tab-active-hover-background: #e4e4e4; /* Hardcoded color */
 	--gnome-tabbar-tab-needs-attetion: var(--gnome-accent);
 	
 	--gnome-tabbar-identity-color-blue: var(--gnome-accent);
@@ -144,24 +144,24 @@
 :root:-moz-window-inactive {
 	--gnome-headerbar-background: var(--gnome-window-background);
 	--gnome-tabbar-tab-hover-background: #f3f3f3; /* Hardcoded color */
-	--gnome-tabbar-tab-active-background: #EFEFEF; /* Hardcoded color */
+	--gnome-tabbar-tab-active-background: #f0f0f0; /* Hardcoded color */
 }
 
 /* Private colors */
 :root[privatebrowsingmode="temporary"] {
 	--gnome-accent-fg: var(--gnome-palette-blue-4);
 	/* Headerbar */
-	--gnome-headerbar-background: #D7E3F0 !important;
+	--gnome-headerbar-background: #eaf2fc !important;
 	/* Tabs */
-	--gnome-tabbar-tab-hover-background: #cbd7e3; /* Hardcoded color */
-	--gnome-tabbar-tab-active-background: #c6d1dd; /* Hardcoded color */
+	--gnome-tabbar-tab-hover-background: #dde5ee; /* Hardcoded color */
+	--gnome-tabbar-tab-active-background: #d8dfe8; /* Hardcoded color */
 	--gnome-tabbar-tab-active-background-contrast: #a9b6c4; /* Hardcoded color */
-	--gnome-tabbar-tab-active-hover-background: #c0cbd7; /* Hardcoded color */
+	--gnome-tabbar-tab-active-hover-background: #d1d8e1; /* Hardcoded color */
 }
 
 /* Private and backdrop colors */
 :root[privatebrowsingmode="temporary"]:-moz-window-inactive {
-	--gnome-headerbar-background: #D7E3F0 !important;
+	--gnome-headerbar-background: #eaf0f7 !important;
 	--gnome-tabbar-tab-hover-background: #e4e9f0; /* Hardcoded color */
 	--gnome-tabbar-tab-active-background: #e1e7ed; /* Hardcoded color */
 }

--- a/theme/parts/headerbar.css
+++ b/theme/parts/headerbar.css
@@ -4,7 +4,6 @@
 /* Headerbar */
 #nav-bar {
 	background: var(--gnome-headerbar-background) !important;
-	border-bottom: 1px solid var(--gnome-headerbar-shade-color) !important;
 	padding: 6px 3px !important;
 }
 

--- a/theme/parts/tabsbar.css
+++ b/theme/parts/tabsbar.css
@@ -102,7 +102,6 @@ spacer[part=overflow-start-indicator], spacer[part=overflow-end-indicator] {
 	display: block;
 	width: 200%;
 	background: var(--gnome-toolbar-background);
-	border-bottom: 1px solid var(--gnome-toolbar-border-color);
 	height: 0;
 	min-height: 0;
 	position: absolute;
@@ -114,7 +113,7 @@ spacer[part=overflow-start-indicator], spacer[part=overflow-end-indicator] {
 /* Tab */
 .tabbrowser-tab {
 	border-width: 0 !important;
-	padding: 5px 2px 6px !important;
+	padding: 0px 2px 6px !important;
 	position: relative;
 }
 .tabbrowser-tab:not([hidden=true], [pinned]):first-of-type {
@@ -584,7 +583,12 @@ tab {
 			order: 2 !important;
 		}
 	}
-	
+
+	/* Padding should be removed on the side touching the URL bar */
+	.tabbrowser-tab {
+		padding-bottom: 0px !important;
+	}
+
 	/* Remove nav-bar rounding and padding */
 	:root[tabsintitlebar][sizemode="normal"]:not([gtktiledwindow="true"]) #nav-bar { 
 		border-radius: 0 !important; 
@@ -600,6 +604,7 @@ tab {
 		border-radius: env(-moz-gtk-csd-titlebar-radius) env(-moz-gtk-csd-titlebar-radius) 0 0 !important
 	}
 	:root[tabsintitlebar]:not([inFullscreen], [sizemode="maximized"]) #TabsToolbar .toolbar-items {
+		margin-block: auto;
 		padding: 0 46px;
 	}
 	

--- a/theme/parts/tabsbar.css
+++ b/theme/parts/tabsbar.css
@@ -38,10 +38,15 @@ tab > stack {
 	--gnome-tabbar-fade-background: var(--gnome-tabbar-background);
 }
 
+#scrollbutton-up,
+#scrollbutton-down {
+	border-top: 0 !important;
+}
+
 #scrollbutton-up:not([disabled])::after,
 #scrollbutton-down:not([disabled])::after {
 	content: "";
-	height: 44px;
+	height: 39px;
 	position: absolute;
 	top: -3px;
 	z-index: -1;
@@ -84,7 +89,7 @@ spacer[part=overflow-start-indicator], spacer[part=overflow-end-indicator] {
 /* Tabsbar buttons */
 #TabsToolbar .toolbarbutton-1:not(#hack) {
 	border-radius: 6px !important;
-	margin: 5px 3px 6px !important;
+	margin: 0px 3px 6px !important;
 	padding: 0 9px !important;
 	min-height: 34px !important;
 	transition: background 0.3s;
@@ -138,11 +143,11 @@ spacer[part=overflow-start-indicator], spacer[part=overflow-end-indicator] {
 	--gnome-tabbar-tab-separator-hack1: linear-gradient(
 		to bottom,
 		var(--gnome-tabbar-tab-separator-hack0) 0,
-		var(--gnome-tabbar-tab-separator-hack0) 9px,
-		var(--gnome-tabbar-tab-separator-color) 9px,
-		var(--gnome-tabbar-tab-separator-color) 35px,
-		var(--gnome-tabbar-tab-separator-hack0) 35px,
-		var(--gnome-tabbar-tab-separator-hack0) 45px
+		var(--gnome-tabbar-tab-separator-hack0) 3px,
+		var(--gnome-tabbar-tab-separator-color) 3px,
+		var(--gnome-tabbar-tab-separator-color) 31px,
+		var(--gnome-tabbar-tab-separator-hack0) 31px,
+		var(--gnome-tabbar-tab-separator-hack0) 40px
 	) 1;
 	border-image: var(--gnome-tabbar-tab-separator-hack1);
 }

--- a/theme/parts/toolbox.css
+++ b/theme/parts/toolbox.css
@@ -9,17 +9,14 @@
 
 /* Toolbox colors */
 #navigator-toolbox {
-	border: 0 !important;
 	background: none !important;
+	border-color: var(--gnome-toolbar-border-color);
 }
 
 #PersonalToolbar, #toolbar-menubar, #TabsToolbar, findbar {
 	appearance: none !important;
 	border: 0 !important;
 	background: var(--gnome-toolbar-background) !important;
-}
-#nav-bar, #PersonalToolbar, #toolbar-menubar:not([inactive=true]), #TabsToolbar {
-	border-bottom: 1px solid var(--gnome-toolbar-border-color) !important;
 }
 findbar {
 	border-top: 1px solid var(--gnome-toolbar-border-color) !important;


### PR DESCRIPTION
GNOME 45 is releasing soon and has a few style changes, which also affect Epiphany too.

https://wiki.gnome.org/FortyFive

- Beta: 5 Aug
- RC: 2 Sep (tomorrow, as of writing this)
- Release: 20 Sep

I've started adjusting colors where I've seen changes, but I'm sure I'm missing a few. So far, it's starting to look pretty close for both the standard light mode and private browsing.

Dark mode doesn't look like it has changed, but I haven't looked too closely.