### PR TITLE
Enable rounded bottom window corners

### DIFF
--- a/configuration/user.js
+++ b/configuration/user.js
@@ -14,3 +14,6 @@ user_pref("svg.context-properties.content.enabled", true);
 // Disable private window dark theme
 user_pref("browser.theme.dark-private-windows", false);
 
+// Enable rounded bottom window corners
+user_pref("widget.gtk.rounded-bottom-corners.enabled", true);
+


### PR DESCRIPTION
Enables the `widget.gtk.rounded-bottom-corners.enabled` preference.