### PR TITLE
Add back customContent support

### DIFF
--- a/userContent.css
+++ b/userContent.css
@@ -5,3 +5,9 @@
 @import "theme/pages/privatebrowsing.css";
 
 @import "theme/parts/video-player.css";
+
+/* Import a custom stylesheet
+ * Everything you add in your customContent.css file (it doesn't exist by
+ * default) will be included here and preserved between updates. 
+ * You can apply your own custom styles in that file. */
+@import "customContent.css"; /**/


### PR DESCRIPTION
Seems like customContent support was forgotten when commit c8ad434 happened. .gitignore still has the `customContent.css` line.