### PR TITLE
Add back the + in tab reborn and fix "only show on new tab" error

### DIFF
--- a/configuration/extensions/tab-center-reborn.css
+++ b/configuration/extensions/tab-center-reborn.css
@@ -74,7 +74,7 @@ body {
 }
 
 #newtab {
-    display:none;
+    width: 95%;
 }
 
 .tab,
@@ -99,7 +99,6 @@ body {
 #newtab-icon {
     min-width: 16px;
 }
-
 
 /* the @media rule only allows these settings apply when the sidebar is expanded */
 @media (min-width: 49px) {
@@ -157,6 +156,7 @@ body {
     background: var(--identity-color);
     transition: inset .1s;
 }
+
 #tablist .tab.active[data-identity-color] .tab-context::before,
 #pinnedtablist:not(.compact) .tab.active[data-identity-color] .tab-context::before {
     top: 1px;

--- a/theme/extensions/tab-center-reborn.css
+++ b/theme/extensions/tab-center-reborn.css
@@ -13,13 +13,21 @@
     #browser {
         position: relative;
     }
+    
+    #tabbrowser-tabbox {
+        z-index: 0 !important;
+    }
+    
+    #navigator-toolbox {
+        z-index: 10 !important;
+    }
 
     #sidebar-box:not([lwt-sidebar]){
         appearance: unset !important;
     }
 
     #sidebar-box[sidebarcommand*="tabcenter"] {
-        z-index: 1;
+        z-index: 1 !important;
     }
 
     #sidebar-box[sidebarcommand*="tabcenter"] #sidebar-header {
@@ -41,7 +49,7 @@
         overflow: hidden;
         
         border-right: 1px solid var(--sidebar-border-color);
-        z-index: 1;
+        z-index: 1 !important;
         top: 0;
         bottom: 0;
     }


### PR DESCRIPTION
this is a change in the CSS of tab reborn to bring back the missed + button from this Issue : https://github.com/rafaelmardojai/firefox-gnome-theme/issues/705