### PR TITLE
toolbox: fix header bar border

### DIFF
--- a/theme/parts/toolbox.css
+++ b/theme/parts/toolbox.css
@@ -10,7 +10,7 @@
 /* Toolbox colors */
 #navigator-toolbox {
 	background: none !important;
-	border-color: var(--gnome-toolbar-border-color);
+	border-color: var(--gnome-toolbar-border-color) !important;
 }
 
 #PersonalToolbar, #toolbar-menubar, #TabsToolbar, findbar {


### PR DESCRIPTION
Currently, the border color is being overridden by `border-bottom: 1px solid ThreeDShadow` in browser-shared.css.

Current border color
![image](https://github.com/piousdeer/firefox-gnome-theme/assets/31318219/41accbd5-090d-4bdb-931e-5832c9deb87a)
Fixed border color
![image](https://github.com/piousdeer/firefox-gnome-theme/assets/31318219/34164689-1cee-4bf4-9aed-a94ae3150215)
