### PR TITLE
Temporary fix for large context menu unusability

### DIFF
--- a/theme/parts/tabsbar.css
+++ b/theme/parts/tabsbar.css
@@ -44,9 +44,9 @@ tab > stack {
 
 #scrollbutton-up,
 #scrollbutton-down {
-	border-top: 0 !important;
-	position: absolute !important;
-	z-index: 5 !important;
+  border-top: 0 !important;
+  position: relative !important;
+  z-index: 5 !important;
   top: 0;
   bottom: 0;
 }


### PR DESCRIPTION
Addresses https://github.com/rafaelmardojai/firefox-gnome-theme/issues/728
For now, I've taken a temporary fix to use the Large context menu. This PR changes the position from absolute to relative and makes some bugs, such as not scrolling naturally when scrolling and some gradients are not correctly positioned to the end of a tablist.

webm (mp4 will be replaced until ffmpeg-full compiles)
[Screencast from 2023-12-31 14-00-56.webm](https://github.com/rafaelmardojai/firefox-gnome-theme/assets/37479424/a96c7c05-8ebe-49fb-81e1-25b924ecc605)
[Screencast from 2023-12-31 14-01-20.webm](https://github.com/rafaelmardojai/firefox-gnome-theme/assets/37479424/d3d67204-9d2e-4f9f-ab1d-1a4709301282)
