### PR TITLE
Set concrete colours for toolbar border

### DIFF
--- a/theme/colors/dark.css
+++ b/theme/colors/dark.css
@@ -28,7 +28,7 @@
 
 		/* Header bar */
 		--gnome-headerbar-background: #303030;
-		--gnome-headerbar-shade-color: color-mix(in srgb, black 36%, transparent);
+		--gnome-headerbar-shade-color: rgba(0, 0, 0, 0.9);
 
 		/* Toolbars */
 		--gnome-toolbar-icon-fill: #eeeeec;

--- a/theme/colors/light.css
+++ b/theme/colors/light.css
@@ -85,11 +85,10 @@
 	
 	/* Header bar */
 	--gnome-headerbar-background: #ffffff;
-	--gnome-headerbar-shade-color: rgba(0, 0, 0, 0.07);
+	--gnome-headerbar-shade-color: rgba(0, 0, 0, 0.12);
 
 	/* Toolbars */
 	--gnome-toolbar-background: var(--gnome-headerbar-background);
-	--gnome-toolbar-color: var(--gnome-window-color);
 	--gnome-toolbar-border-color: var(--gnome-headerbar-shade-color);
 	--gnome-toolbar-icon-fill: #2f2f2f;
 	

--- a/theme/parts/buttons.css
+++ b/theme/parts/buttons.css
@@ -52,7 +52,7 @@ button.close,
 	max-height: 34px !important;
 	min-height: 34px !important;
 	min-width: 34px !important;
-	color: var(--gnome-toolbar-color) !important;
+	color: var(--gnome-window-color) !important;
 	outline: 0 !important;
 	font: menu !important;
 	-moz-box-align: center !important;

--- a/theme/parts/findbar.css
+++ b/theme/parts/findbar.css
@@ -8,7 +8,7 @@ findbar {
 }
 
 findbar label, findbar description {
-	color: var(--gnome-toolbar-color) !important;
+	color: var(--gnome-window-color) !important;
 }
 
 .findbar-container {

--- a/theme/parts/headerbar.css
+++ b/theme/parts/headerbar.css
@@ -18,7 +18,7 @@
 	height: 46px;
 	top: 0;
 	transform: translate(15px, 0);
-	fill: var(--gnome-toolbar-color) !important;
+	fill: var(--gnome-window-color) !important;
 	fill-opacity: 0.2 !important;
 	-moz-context-properties: fill, fill-opacity;
   }

--- a/theme/parts/popups-contents.css
+++ b/theme/parts/popups-contents.css
@@ -223,7 +223,7 @@
 }
 
 #protections-popup-mainView-panel-header {
-	color: var(--gnome-toolbar-color) !important;
+	color: var(--gnome-window-color) !important;
 }
 #protections-popup[hasException] #protections-popup-mainView-panel-header {
 	background: none !important;
@@ -251,13 +251,13 @@
 	background-color: var(--gnome-entry-background);
 	border: 0 !important;
 	border-radius: 12px;
-	color: var(--gnome-toolbar-color) !important;
+	color: var(--gnome-window-color) !important;
 	height: 100% !important;
 	margin: 0 !important;
 }
 #protections-popup-message .text-link,
 #cfr-protections-panel-link-text {
-	color: var(--gnome-toolbar-color) !important;
+	color: var(--gnome-window-color) !important;
 }
 .whatsNew-message-body {
 	padding: 0 6px;

--- a/theme/parts/popups.css
+++ b/theme/parts/popups.css
@@ -5,7 +5,7 @@
 /* Style menus */
 menupopup {
 	-moz-appearance: none !important;	
-	color: var(--gnome-toolbar-color) !important;
+	color: var(--gnome-window-color) !important;
 	padding: 8px !important;
 }
 
@@ -132,7 +132,7 @@ panel  {
 	background: var(--arrowpanel-background) !important;
 	border: 1px solid var(--gnome-menu-border-color) !important;
 	border-radius: 12px !important;
-	color: var(--gnome-toolbar-color) !important;
+	color: var(--gnome-window-color) !important;
 }
 .panel-arrow {    
 	fill: var(--arrowpanel-background) !important;
@@ -187,7 +187,7 @@ panelview .unified-extensions-item-action-button,
 #downloadsPanel-mainView .download-state {
 	-moz-appearance: none !important;
 	border-radius: 6px !important;	
-	color: var(--gnome-toolbar-color) !important;
+	color: var(--gnome-window-color) !important;
 	font: menu !important;
 	padding: 4px 12px !important;
 	min-height: 32px !important;

--- a/theme/parts/tabsbar.css
+++ b/theme/parts/tabsbar.css
@@ -198,7 +198,7 @@ spacer[part=overflow-start-indicator], spacer[part=overflow-end-indicator] {
 
 /* Tab labels */
 tab {
-	color: var(--gnome-toolbar-color) !important;
+	color: var(--gnome-window-color) !important;
 	font-family: Cantarell, inherit;
 	font-weight: normal;
 	font-size: 1em;
@@ -331,7 +331,7 @@ tab {
 /* Close tab button */
 .tab-close-button {
 	list-style-image: url("../icons/window-close-symbolic.svg") !important;
-	fill: var(--gnome-toolbar-color) !important;
+	fill: var(--gnome-window-color) !important;
 	fill-opacity: 1 !important;
 	-moz-context-properties: fill, fill-opacity !important;
 	height: 16px !important;

--- a/theme/parts/toolbox.css
+++ b/theme/parts/toolbox.css
@@ -9,7 +9,7 @@
 
 /* Toolbox colors */
 #navigator-toolbox {
-	background: none !important;
+	background: var(--gnome-toolbar-background) !important;
 	border-color: var(--gnome-toolbar-border-color) !important;
 }
 

--- a/theme/parts/urlbar.css
+++ b/theme/parts/urlbar.css
@@ -41,7 +41,7 @@ toolbarspring {
 /* URL bar results */
 .urlbarView {
 	background: transparent !important;
-	color: var(--gnome-toolbar-color) !important;
+	color: var(--gnome-window-color) !important;
 	margin: 11px 0 0 -3px !important;
 	width: 100% !important;
     position: absolute !important;
@@ -163,7 +163,7 @@ toolbarspring {
 	padding-right: 0 !important;
 }
 #urlbar-search-mode-indicator-title {
-	color: var(--gnome-toolbar-color);
+	color: var(--gnome-window-color);
 	padding-inline: 4px !important;
 }
 #urlbar-search-mode-indicator-close {


### PR DESCRIPTION
![light](https://github.com/rafaelmardojai/firefox-gnome-theme/assets/69783006/6e504273-8dc3-4591-9b45-ce340d52dcaa)
![dark](https://github.com/rafaelmardojai/firefox-gnome-theme/assets/69783006/6cae8ff1-c511-42f0-b9b5-7177e595b458)

This makes it look identical to the border in GNOME Web.