### PR TITLE
Disabling option for animation of vertical tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ We also have optional features to enable support for some Firefox extensions.
 
 	> **Note:** You also need to copy the contents of the file `configuration/extensions/tab-center-reborn.css` into the settings page of Tabcenter-reborn..\
 	> **Note2:** You can also maintain the vertical tab always open with `gnomeTheme.extensions.tabCenterReborn.alwaysOpen`
+ 	> **Note2:** You can disable animation by disabling animation into the extension and adding the flags `gnomeTheme.extensions.tabCenterReborn.animationDisabled`
 	
 ## Known bugs
 

--- a/theme/extensions/tab-center-reborn.css
+++ b/theme/extensions/tab-center-reborn.css
@@ -65,11 +65,13 @@
         width: 30vw !important;
         max-width: 200px !important;
         z-index: 1 !important;
+        animation-timing-function: linear;
         transition: all var(--transition-time) ease var(--delay);
     }
 
     #sidebar-box[sidebarcommand*="tabcenter"]:not(:hover) #sidebar,
     #sidebar-box[sidebarcommand*="tabcenter"]:not(:hover) {
+        animation-timing-function: linear;
         transition: all var(--transition-time) ease 0s;
     }
 
@@ -166,4 +168,19 @@
             max-width: 250px !important;
         }
     }
+}
+
+@media (-moz-bool-pref: "gnomeTheme.extensions.tabCenterReborn.animationDisabled") {
+    #sidebar-box[sidebarcommand*="tabcenter"]:hover #sidebar,
+    #sidebar-box[sidebarcommand*="tabcenter"]:hover {
+        transition: none !important;
+    }
+
+    #sidebar-box[sidebarcommand*="tabcenter"]:not(:hover) #sidebar,
+    #sidebar-box[sidebarcommand*="tabcenter"]:not(:hover) {
+        animation-timing-function: linear;
+        transition: none !important;
+    }
+    
+    
 }


### PR DESCRIPTION
Add an option to disable animation like asked in : https://github.com/rafaelmardojai/firefox-gnome-theme/issues/737#issuecomment-1879174801

@rafaelmardojai 