### PR TITLE
tabsbar: Fix performance issue when using gnomeTheme.hideSingleTab

### DIFF
--- a/theme/parts/tabsbar.css
+++ b/theme/parts/tabsbar.css
@@ -555,9 +555,11 @@ tab {
 
 /* OPTIONAL: Hide single tab */
 @media (-moz-bool-pref: "gnomeTheme.hideSingleTab") {
-	#tabbrowser-tabs:not(:has(tab:not([hidden="true"]) ~ tab:not([hidden="true"]))) tab,
-	#tabbrowser-tabs:not(:has(tab:not([hidden="true"]) ~ tab:not([hidden="true"]))) tab ~ toolbarbutton,
-	#tabbrowser-tabs:not(:has(tab:not([hidden="true"]) ~ tab:not([hidden="true"]))) tab ~ #tabbrowser-arrowscrollbox-periphery {
+	#tabbrowser-tabs:not(:has(tab:not([hidden="true"]) ~ tab:not([hidden="true"]))) :is(
+		tab,
+		tab ~ toolbarbutton,
+		tab ~ #tabbrowser-arrowscrollbox-periphery
+	) {
 		visibility: collapse;
 	}
 }


### PR DESCRIPTION
Fixes #751

I think this is a bug in Servo.