### PR TITLE
Issue #755 Fix

### DIFF
--- a/theme/system-icons.css
+++ b/theme/system-icons.css
@@ -75,6 +75,8 @@
 	#TabsToolbar #new-tab-button .toolbarbutton-icon {
 		filter: var(--gnome-icons-hack-filter);
 		list-style-image: url("moz-icon://stock/tab-new-symbolic?size=dialog") !important;
+		width: 16px !important;
+		height:16px !important;
 	}
 	/* Home button */
 	#home-button .toolbarbutton-icon {


### PR DESCRIPTION
Fixed Issue #755 by locking size of new tab icon when system icons are enabled. Please see bug report for more description. 