### PR TITLE
fix: urlbar suggestions overlapping

### DIFF
--- a/theme/parts/urlbar.css
+++ b/theme/parts/urlbar.css
@@ -8,7 +8,7 @@
 }
 
 #urlbar-container {
-	--urlbar-container-height: 0 !important;
+	--urlbar-container-height: 34px !important;
 }
 
 /* Center the URL bar */


### PR DESCRIPTION
For a few days, with one of the latest versions of firefox, the list of suggestions overlaps the URL bar, preventing from interacting with it like to select the text in it or editing. The issue seems to be caused by `--urlbar-container-height` set to 0. The fix set its value as the same value of urlbar height.