### PR TITLE
Add an OLED black theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,11 @@ Optional features can be enabled by creating new `boolean` preferences in `about
 	
 	> **Note:** Enabling with `gnomeTheme.hideSingleTab` will replace the single tab with a title bar.
 
+- **OLED black theme** `gnomeTheme.oledBlack`
+
+	Change the dark theme into the black variant.
+	
+
 ### Extensions support
 
 We also have optional features to enable support for some Firefox extensions.

--- a/theme/colors/black.css
+++ b/theme/colors/black.css
@@ -1,0 +1,80 @@
+@namespace xul url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
+
+/* Variables that start with --gnome- are added by me and are assigned
+ * to elements somewhere in this code. The rest of the variables are
+ * built-in in Firefox, so you need to add an !important if you wanna
+ * override them. */
+@media (prefers-color-scheme: dark) {	
+	:root {
+		/* Accent */
+		--gnome-accent-bg: #1161CB;
+		--gnome-accent: #1161CB;
+
+		--gnome-toolbar-star-button: var(--gnome-palette-yellow-1);
+
+		/* Window */
+		--gnome-window-background: #000000;
+		--gnome-window-color: white;
+		--gnome-view-background: #1e1e1e;
+		--gnome-sidebar-background: #303030;
+		--gnome-secondary-sidebar-background: #2a2a2a;
+
+		/* Card */
+		--gnome-card-background: rgba(255, 255, 255, 0.08);
+		--gnome-card-shade-color: color-mix(in srgb, black 36%, transparent);
+
+		/* Menu */
+		--gnome-menu-background: #303030;
+
+		/* Header bar */
+		--gnome-headerbar-background: #000000;
+		--gnome-headerbar-shade-color: rgba(0, 0, 0, 0.9);
+
+		/* Toolbars */
+		--gnome-toolbar-icon-fill: #eeeeec;
+
+		/* Tabs */
+		--gnome-tabbar-tab-hover-background: #252524; /* Hardcoded color */
+		--gnome-tabbar-tab-active-background: #191918; /* Hardcoded color */
+		--gnome-tabbar-tab-active-background-contrast: #4F4F4F; /* Hardcoded color */
+		--gnome-tabbar-tab-active-hover-background: #272725; /* Hardcoded color */
+		
+		--gnome-tabbar-identity-color-green: var(--gnome-palette-green-1);
+		--gnome-tabbar-identity-color-yellow: var(--gnome-palette-yellow-2);
+		--gnome-tabbar-identity-color-orange: var(--gnome-palette-orange-3);
+		--gnome-tabbar-identity-color-red: var(--gnome-palette-red-1);
+		--gnome-tabbar-identity-color-purple: var(--gnome-palette-purple-1);
+		
+		/* Text color for Firefox Logo in new private tab */
+		--gnome-private-wordmark: #FBFBFE;
+		/* New private tab background */
+		--gnome-private-in-content-page-background: #242424;
+		/* Private browsing info box */
+		--gnome-private-text-primary-color: #FBFBFE;
+	}
+
+	/* Backdrop colors */
+	:root:-moz-window-inactive {
+		--gnome-tabbar-tab-hover-background: #2c2c2c; /* Hardcoded color */
+		--gnome-tabbar-tab-active-background: #2e2e2e; /* Hardcoded color */
+	}
+
+	/* Private colors */
+	:root[privatebrowsingmode="temporary"] {
+		--gnome-accent-fg: #78aeed;
+		/* Headerbar */
+		--gnome-headerbar-background: #252F49 !important;
+		/* Tabs */	
+		--gnome-tabbar-tab-hover-background: #343e56; /* Hardcoded color */
+		--gnome-tabbar-tab-active-background: #343e56; /* Hardcoded color */
+		--gnome-tabbar-tab-active-background-contrast: #495675; /* Hardcoded color */
+		--gnome-tabbar-tab-active-hover-background: #414a61; /* Hardcoded color */
+	}
+
+	/* Private and backdrop colors */
+	:root[privatebrowsingmode="temporary"]:-moz-window-inactive {
+		--gnome-headerbar-background: #252F49 !important;
+		--gnome-tabbar-tab-hover-background: #242c3f; /* Hardcoded color */
+		--gnome-tabbar-tab-active-background: #272e41; /* Hardcoded color */
+	}
+}

--- a/theme/gnome-theme.css
+++ b/theme/gnome-theme.css
@@ -24,6 +24,7 @@
 
 @import "colors/light.css";
 @import "colors/dark.css";
+@import "colors/black.css" screen and (-moz-bool-pref: "gnomeTheme.oledBlack"); 
 
 @import "system-icons.css";
 @import "symbolic-tab-icons.css";


### PR DESCRIPTION
Added an OLED black theme (for OLED display)

![image](https://github.com/rafaelmardojai/firefox-gnome-theme/assets/55012032/e65e5c73-1e90-4d2d-8cf9-2ee22b151a2d)
