### PR TITLE
Add Floorp to auto-install.sh, label FF distributions therein

### DIFF
--- a/scripts/auto-install.sh
+++ b/scripts/auto-install.sh
@@ -4,11 +4,19 @@ sysThemeNames=("'Pop'" "'Pop-dark'" "'Pop-light'" "'Yaru'" "'Yaru-dark'" "'Yaru-
 themeNames=("pop" "pop" "pop" "yaru" "yaru" "yaru" "maia" "maia")
 
 firefoxInstallationPaths=(
-    ~/.mozilla/firefox
-    ~/.var/app/org.mozilla.firefox/.mozilla/firefox
-    ~/.librewolf
-    ~/.var/app/io.gitlab.librewolf-community/.librewolf
-    ~/snap/firefox/common/.mozilla/firefox
+    # Firefox
+    ~/.mozilla/firefox # Package
+    ~/.var/app/org.mozilla.firefox/.mozilla/firefox # Flatpak
+    ~/snap/firefox/common/.mozilla/firefox # Snap
+
+    # Librewolf
+    ~/.librewolf # Package
+    ~/.var/app/io.gitlab.librewolf-community/.librewolf # Flatpak
+
+    # Floorp
+    ~/.floorp # Package
+    ~/.var/app/one.ablaze.floorp/.floorp # Flatpak
+    
 )
 
 currentTheme=$(gsettings get org.gnome.desktop.interface gtk-theme ) || currentTheme=""


### PR DESCRIPTION
Here's a commit to add [Floorp](https://floorp.app/en/) support to auto-install.sh.

This assumes the user is using the Proton UI option within Floorp's "Design" settings tab.
![Selecting the Firefox Proton design option within the Design settings tab in Floorp.](https://github.com/rafaelmardojai/firefox-gnome-theme/assets/92271574/69a9531b-cb23-4d3d-ab21-cced95058b62)

Floorp has a GNOME theme built in (presumably this one?), but it has since been deprecated and has some usability issues. I also hope it's no issue that I added some labeling to the `firefoxInstallationPaths` list in `./scripts/auto-install.sh` for the sake of organisation and clarity.
