### PR TITLE
Add separator for the sidebar

### DIFF
--- a/theme/extensions/tab-center-reborn.css
+++ b/theme/extensions/tab-center-reborn.css
@@ -22,6 +22,10 @@
         z-index: 10 !important;
     }
 
+    #sidebar-box{
+        border-right: 0.01px solid var(--chrome-content-separator-color) !important;
+    }
+
     #sidebar-box:not([lwt-sidebar]){
         appearance: unset !important;
     }


### PR DESCRIPTION
As reported in this feedback no separator where showed on the sidebar.

Fix Issue : https://github.com/rafaelmardojai/firefox-gnome-theme/issues/781