### PR TITLE
urlbar: Fix icon positioning

### DIFF
--- a/theme/parts/urlbar.css
+++ b/theme/parts/urlbar.css
@@ -149,6 +149,12 @@ toolbarspring {
 	height: 100%  !important;
 }
 
+@media (-moz-bool-pref: "browser.urlbar.richSuggestions.featureGate") {
+	#urlbar:not(.searchButton) > #urlbar-input-container > #identity-box[pageproxystate="invalid"] > .identity-box-button {
+		margin-inline-start: 2px;
+	}
+}
+
 /* Search mode indicator */
 #urlbar-search-mode-indicator,
 #urlbar-label-box,


### PR DESCRIPTION
you can see that on the new tab page with `browser.urlbar.richSuggestions.featureGate` enabled