### PR TITLE
Add Option to align text and favicon in tab left

### DIFF
--- a/theme/parts/tabsbar.css
+++ b/theme/parts/tabsbar.css
@@ -571,6 +571,14 @@ tab {
 	}
 }
 
+/* OPTIONAL: Align tab items left */
+@media (-moz-bool-pref: "gnomeTheme.tabAlignLeft") {
+	.tabbrowser-tab:not([pinned]) .tab-icon-stack {
+		margin-left: 0 !important;
+		padding: 0 5px !important;
+	}
+}
+
 /* OPTIONAL: Hide single tab */
 @media (-moz-bool-pref: "gnomeTheme.hideSingleTab") {
 	#tabbrowser-tabs:not(:has(tab:not([hidden="true"]) ~ tab:not([hidden="true"]))) :is(


### PR DESCRIPTION
This is just something I have in my personal use (with allTabsButton, normalWidthTabs and tabsAsHeaderbar), thought I'd send it upstream if someone else might find it useful.

All this does is add that as the option tabAlignLeft.
One thing that I noticed when checking with other options is that it looks slightly strange with swapTabClose as that then leaves a gap in unfocused tabs.