### PR TITLE
Add macOS compatibility to the install script

### DIFF
--- a/scripts/auto-install.sh
+++ b/scripts/auto-install.sh
@@ -8,6 +8,7 @@ firefoxInstallationPaths=(
     ~/.mozilla/firefox # Package
     ~/.var/app/org.mozilla.firefox/.mozilla/firefox # Flatpak
     ~/snap/firefox/common/.mozilla/firefox # Snap
+    "$HOME/Library/Application Support/Firefox" # MacOS Package
 
     # Librewolf
     ~/.librewolf # Package
@@ -34,10 +35,10 @@ for i in "${!sysThemeNames[@]}"; do
 done
 
 for folder in "${firefoxInstallationPaths[@]}"; do
-    if [ -d $folder ]; then
+    if [ -d "$folder" ]; then
     echo Firefox installation folder found
 
-    folderArg=" -f $folder"
+    folderArg=" -f \"$folder\""
     eval ${installScript}${themeArg}${folderArg}   
     foldersFoundCount+=1
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -107,8 +107,16 @@ function saveProfile(){
 
 	echo "Set configuration to user.js file" >&2
 
-	mapfile -t theme_prefs < <( grep "user_pref" chrome/firefox-gnome-theme/configuration/user.js )
-	mapfile -t theme_prefs_unvalued < <( grep "user_pref" chrome/firefox-gnome-theme/configuration/user.js|cut -d'"' -f 2 )
+  theme_prefs=()
+  while IFS= read -r line; do
+    theme_prefs+=("$line")
+  done < <(grep "user_pref" chrome/firefox-gnome-theme/configuration/user.js)
+  
+  theme_prefs_unvalued=()
+  while IFS= read -r line; do
+    theme_prefs_unvalued+=("$line")
+  done < <(grep "user_pref" chrome/firefox-gnome-theme/configuration/user.js | cut -d'"' -f 2)
+
 	if [ ! -f "user.js" ]; then
 		mv chrome/firefox-gnome-theme/configuration/user.js .
 	else


### PR DESCRIPTION
I love and always use this theme, and I'm on macOS right now, so I thought it would be nice for the install script to have compatibility with it.
 
#### Changes
- added  macOS path for Firefox and handled spaces
- addressed differences in `sed` on BSD-like platforms
- replaced `mapfile` command, as it is not present in the default bash version bundled with macOS