### PR TITLE
extensions: tab-center-reborn: Fix URL bar going out of bounds

### DIFF
--- a/theme/extensions/tab-center-reborn.css
+++ b/theme/extensions/tab-center-reborn.css
@@ -133,11 +133,7 @@
 
 @media (max-width: 630px) {
     #urlbar-container {
-        min-width: 100% !important;
-    }
-
-    #menubar-items {
-        display: none !important;
+        width: auto !important;
     }
 }
 


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/c9bc8a34-0c22-4ccc-bbcc-7730dd58a1be)

after:
![image](https://github.com/user-attachments/assets/bc9a28e4-bda7-424b-9a8e-491e7339eb69)

also fixes the menubar not appearing on small windows