### PR TITLE
Fixed close tab button overlay transition

### DIFF
--- a/theme/parts/tabsbar.css
+++ b/theme/parts/tabsbar.css
@@ -283,7 +283,7 @@ tabs#tabbrowser-tabs {
 					position: absolute;
 					right: 2px;
 					top: 2px;
-					transition: background 0.4s linear;
+					transition: all 0.2s linear;
 					width: 55px;
 					z-index: 99;
 				}

--- a/theme/parts/tabsbar.css
+++ b/theme/parts/tabsbar.css
@@ -283,7 +283,7 @@ tabs#tabbrowser-tabs {
 					position: absolute;
 					right: 2px;
 					top: 2px;
-					transition: all 0.2s linear;
+					transition: opacity 0.2s linear;
 					width: 55px;
 					z-index: 99;
 				}


### PR DESCRIPTION
Changed transition property from `background` to `opacity` (as this is what changes on hover). Also synced it with the duration of background transition of tab's background color. This makes tab hover animation a bit smoother.