### PR TITLE
Add Microsoft Windows (Git Bash) compatibility to the install script

### DIFF
--- a/scripts/auto-install.sh
+++ b/scripts/auto-install.sh
@@ -6,6 +6,7 @@ firefoxInstallationPaths=(
     ~/.var/app/org.mozilla.firefox/.mozilla/firefox # Flatpak
     ~/snap/firefox/common/.mozilla/firefox # Snap
     "$HOME/Library/Application Support/Firefox" # MacOS Package
+    ~/AppData/Roaming/Mozilla/Firefox # Microsoft Windows
 
     # Librewolf
     ~/.librewolf # Package

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -48,7 +48,8 @@ function saveProfile(){
 
 	# Copy theme repo inside
 	echo "Copying repo in $PWD" >&2
-	cp -fR "$THEMEDIRECTORY" "$PWD" || { echo "FAIL, couldn't copy to $PWD/chrome, please check if there's something named 'chrome', that is not a dir."; exit 1; }
+	[ -e ./firefox-gnome-theme ] || mkdir firefox-gnome-theme
+	cp -fR "$THEMEDIRECTORY/." "$PWD/firefox-gnome-theme/" || { echo "FAIL, couldn't copy to $PWD/chrome, please check if there's something named 'chrome' or 'chrome/firefox-gnome-theme', that is not a dir."; exit 1; }
 
 	# Create single-line user CSS files if non-existent or empty.
 	if [ -s userChrome.css ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,7 +24,7 @@ done
 #
 # sed in BSD platforms need this extra argument when using '-i' to specify no backup file.
 function _sed(){
-  if [[ "$OSTYPE" == *"linux"* ]]; then
+  if [[ "$OSTYPE" == *"linux"* ]] || [[ "$OSTYPE" == *msys* ]]; then
     sed "$@"
     return $?
   fi


### PR DESCRIPTION
Inspired by https://github.com/rafaelmardojai/firefox-gnome-theme/pull/848

Prerequisites:
- Git Bash or msys2
- (default behavior on Git Bash) The `$HOME` corresponds to the `%USERPROFILE%` on Microsoft Windows
- `%APPDATA%` remains default value on Microsoft Windows