### PR TITLE
fix: prevent overflow in 'Ctrl+q' dialog

### DIFF
--- a/theme/parts/dialogs.css
+++ b/theme/parts/dialogs.css
@@ -4,6 +4,7 @@
 
 window {
 	padding: 0 !important;
+	width: initial !important;
 }
 
 dialog {	
@@ -53,9 +54,28 @@ dialog {
 		justify-content: center !important;
 	}
 
+	#titleCropper {
+		&[overflown] {
+			mask-image: none !important;
+			
+			#titleText {
+				display: inline-block !important;
+				max-width: 100% !important;
+				overflow: hidden !important;
+				text-overflow: ellipsis;
+			}
+		}
+
+		&:not([nomaskfade]) {
+			display: initial !important;
+		}
+	}
+
 	#titleText {
 		font-size: 20px !important;
 		font-weight: 800 !important;
+		text-align: center !important;
+		white-space: initial !important;
 	}
 
 	.titleIcon {
@@ -72,6 +92,10 @@ dialog {
 	
 	#infoContainer {
 		text-align: center;
+	}
+
+	#checkboxContainer {
+		align-items: center !important;
 	}
 }
 
@@ -91,6 +115,18 @@ dialog {
 		border-radius: 12px !important;
 		flex: 1;
 		border-bottom: 0 !important;
+		
+		.button-box {
+			max-width: 100%;
+			.button-text {
+				max-width: 100%;		
+				&::before {					
+					max-width: 100% !important;
+					overflow: hidden !important;
+					text-overflow: ellipsis;
+				}
+			}
+		}
 	}
 	
 	.button-spacer {


### PR DESCRIPTION
Prevents overflow in 'Ctrl+q' exit confirmation dialog. I've also centered the checkbox prompt.

before:
![Screenshot-2025-03-08_07:56PM](https://github.com/user-attachments/assets/1545aca2-50b0-454a-b1fd-508bc856ab5a)

after:
![Screenshot-2025-03-08_07:54PM](https://github.com/user-attachments/assets/32d34718-e077-40e4-b58d-4fce19749898)
