### PR TITLE
Added Waterfox folder path

### DIFF
--- a/scripts/auto-install.sh
+++ b/scripts/auto-install.sh
@@ -15,6 +15,9 @@ firefoxInstallationPaths=(
     # Floorp
     ~/.floorp # Package
     ~/.var/app/one.ablaze.floorp/.floorp # Flatpak
+
+    # Waterfox
+    ~/.var/app/net.waterfox.waterfox/.waterfox # Flatpak
     
 )
 


### PR DESCRIPTION
Waterfox is yet another privacy-centered Firefox fork with minimal decorations, so the firefox-gnome-theme should work right out of the box. (there's also a tarball version, but since the user may install it anywhere, it's not possible to define)