### PR TITLE
Fix missing window buttons on macOS

### DIFF
--- a/theme/parts/csd.css
+++ b/theme/parts/csd.css
@@ -84,7 +84,6 @@
 			gap: 13px;
 
 			.titlebar-button {
-				appearance: none !important;
 				padding: 0 !important;
 				margin: 0 !important;
 				


### PR DESCRIPTION
This PR fixes the issue of missing window buttons on macOS by adjusting the appearance property in csd.css. The buttons also work as expected.

The fix was tested on:

✅ macOS
✅ XFCE 4.20 (X11)
❌ Not tested on GNOME (no access to a GNOME environment)

I kindly ask the maintainer to test it on GNOME. If it doesn't break anything, consider merging it.

Fixes issue [#773](https://github.com/rafaelmardojai/firefox-gnome-theme/issues/773).

Some screenshots (nothing broken when changing between light and dark modes):

<img width="1512" alt="light" src="https://github.com/user-attachments/assets/3a0d9e06-0c90-4ef2-9a87-5de99efe8265" />
<img width="1512" alt="dark" src="https://github.com/user-attachments/assets/e33a0af5-1755-4a21-8798-5dc671002da6" />
