### PR TITLE
Darken tools-and-extensions in sidebar when inactive

### DIFF
--- a/theme/parts/sidebar.css
+++ b/theme/parts/sidebar.css
@@ -41,6 +41,7 @@ link[href="chrome://browser/content/sidebar/sidebar-main.css"] + .wrapper {
 
 #sidebar-box:-moz-window-inactive label, #sidebar-box:-moz-window-inactive image,
 .sidebar-panel:-moz-window-inactive label, .sidebar-panel:-moz-window-inactive image,
+.tools-and-extensions:-moz-window-inactive,
 .sidebar-placesTreechildren:-moz-window-inactive {
 	opacity: 0.7 !important;
 }


### PR DESCRIPTION
Darkens tools-and-extensions at bottom of sidebar like the rest of it.

~One thing I noticed additionally is that the "white" of the icons in the vertical tab area and that in the new tab button are slightly different. I can't see this when the window is active (#eeeeec vs #ffffff) but it gets more visible when darkened (#8c8c8b vs #bfbfbf)~ edit: that seems to be resolved by 229be66