### PR TITLE
Add adaptive tab bar colour support

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,10 @@ We also have optional features to enable support for some Firefox extensions.
 	> **Note:** You also need to copy the contents of the file `configuration/extensions/tab-center-reborn.css` into the settings page of Tabcenter-reborn..\
 	> **Note2:** You can also maintain the vertical tab always open with `gnomeTheme.extensions.tabCenterReborn.alwaysOpen`
  	> **Note2:** You can disable animation by disabling animation into the extension and adding the flags `gnomeTheme.extensions.tabCenterReborn.animationDisabled`
+
+- **Adaptive Tab Bar Colour support** `gnomeTheme.extensions.adaptiveTabBarColour`
+
+	> **Note:** Adaptive Tab Bar Colour presently hard-codes the colours for the home page (both normal as well as private windows). When navigating from the home page to any other page, the colour of the UI might momentarily switch to the original firefox home page colour before switching back to the expected colour (this is especially noticeable in private windows). This only happens when navigating from the homepage to another page, subsequent navigations should be unaffected.
 	
 ## Known bugs
 

--- a/theme/extensions/adaptive-tab-bar-colour.css
+++ b/theme/extensions/adaptive-tab-bar-colour.css
@@ -1,0 +1,73 @@
+:root,
+:root[privatebrowsingmode="temporary"],
+:is(:root, :root[privatebrowsingmode="temporary"]):-moz-window-inactive {
+	/* Colors */
+	--gnome-accent-bg: AccentColor !important;
+	/* Window */
+	--gnome-window-color: var(--lwt-text-color);
+	--gnome-window-background: var(--lwt-accent-color);
+	--gnome-sidebar-background: var(--lwt-accent-color);
+	--gnome-secondary-sidebar-background: var(--sidebar-background-color);
+	/* Menu */
+	--gnome-menu-background: var(--arrowpanel-background);
+	--gnome-menu-color: var(--lwt-text-color);
+	/* Header bar */
+	--gnome-headerbar-background: var(--toolbar-bgcolor) !important;
+	/* Toolbars */
+	--gnome-toolbar-border-color: transparent;
+	--gnome-toolbar-background: var(--toolbar-bgcolor);
+	--gnome-toolbar-icon-fill: var(--toolbarbutton-icon-fill);
+	/* Entries */
+	--gnome-entry-background: var(--toolbar-field-background-color);
+	--gnome-entry-color: var(--toolbar-field-color);
+	--gnome-inactive-entry-color: hsl(from var(--gnome-entry-color) h s calc(l + 5%));
+	--gnome-entry-focused-border-color: var(--gnome-selection-bg);
+	/* Tabs */
+	--gnome-tabbar-background: var(--gnome-headerbar-background);
+	--gnome-tabbar-tab-hover-background: color-mix(in oklab, var(--gnome-tabbar-background), var(--lwt-text-color) 10%);
+	--gnome-tabbar-tab-active-background: var(--tab-selected-bgcolor);
+	--gnome-tabbar-tab-active-hover-background: color-mix(in oklab, var(--gnome-tabbar-tab-active-background), var(--lwt-text-color) 10%);
+
+	/* 'New Tab' and 'New Private Tab' pages */
+	&:has(
+		tab:where(
+			[image="chrome://branding/content/icon32.png"],
+			[image="chrome://browser/skin/privatebrowsing/favicon.svg"]
+		)[selected]
+	) {
+		--lwt-accent-color: var(--gnome-private-in-content-page-background) !important;
+
+		--lwt-text-color: rgba(0, 0, 0, 0.8) !important;
+		--sidebar-background-color: #f3f3f3 !important;
+
+		@media (prefers-color-scheme: dark) {
+			--lwt-text-color: white !important;
+			--sidebar-background-color: #2a2a2a !important;
+		}
+
+		--toolbar-bgcolor: var(--lwt-accent-color) !important;
+		--toolbar-color: var(--lwt-text-color) !important;
+		--toolbar-field-color: var(--lwt-text-color) !important;
+		--toolbarbutton-icon-fill: var(--lwt-text-color) !important;
+		--toolbar-field-focus-background-color: Field !important;
+		--arrowpanel-background: color-mix(in oklab, var(--toolbar-bgcolor), var(--lwt-text-color) 10%) !important;
+		--toolbar-field-background-color: var(--arrowpanel-background) !important;
+		--tab-selected-bgcolor: color-mix(in oklab, var(--gnome-tabbar-background), var(--lwt-text-color) 20%) !important;
+		--lwt-tab-line-color: var(--tab-selected-bgcolor) !important;
+	}
+}
+
+.menupopup-arrowscrollbox, window[role="dialog"] {
+	--gnome-menu-background: Menu;
+	--gnome-window-color: MenuText;
+	--gnome-toolbar-icon-fill: MenuText;
+}
+
+.urlbarView-url {
+	--gnome-headerbar-mix: color-mix(in oklch, var(--gnome-headerbar-background), var(--lwt-text-color) 60%);
+	--gnome-accent: oklch(from var(--gnome-headerbar-mix) l calc(c + 0.01) h);
+}
+
+#sidebar-launcher-splitter, #sidebar-splitter {
+	background-color: color-mix(in oklab, var(--lwt-accent-color), var(--lwt-text-color) 10%) !important;
+}

--- a/theme/gnome-theme.css
+++ b/theme/gnome-theme.css
@@ -23,14 +23,15 @@
 /* Platforms */
 @import "platforms/windows.css" screen and (-moz-platform: windows);
 
-/* Extensions support */
-@import "extensions/tab-center-reborn.css" screen and -moz-pref("gnomeTheme.extensions.tabCenterReborn");
-
 /* Variables */
 @import "variables.css";
 @import "colors/light.css";
 @import "colors/dark.css";
 @import "colors/black.css" screen and -moz-pref("gnomeTheme.oledBlack"); 
+
+/* Extensions support */
+@import "extensions/tab-center-reborn.css" screen and -moz-pref("gnomeTheme.extensions.tabCenterReborn");
+@import "extensions/adaptive-tab-bar-colour.css" screen and -moz-pref("gnomeTheme.extensions.adaptiveTabBarColour");
 
 /* Optional */
 @import "system-icons.css" screen and -moz-pref("gnomeTheme.systemIcons");


### PR DESCRIPTION
It isn't perfect. Because Adaptive Tab Bar Colour presently hardcodes the colour for the home page, navigating from the home page to any other page may momentarily cause the original firefox homepage colour to show before changing back to the expected colour.
This only affects navigations from the home page to another page. Subsequent navigations should be unaffected and should word as expected.
I've mentioned this in the README.