### PR TITLE
fix(sidebar): Move border to left when sidebar moved to right

### DIFF
--- a/theme/parts/sidebar.css
+++ b/theme/parts/sidebar.css
@@ -6,7 +6,14 @@
 #sidebar-main {
 	--button-size-icon: var(--gnome-button-size) !important;
 	background-color: var(--gnome-sidebar-background) !important;
-	border-inline-end: 1px solid var(--gnome-toolbar-border-color) !important;
+
+	&[positionend] {
+		border-inline-start: 1px solid var(--gnome-toolbar-border-color) !important;
+	}
+
+	&:not([positionend]) {
+		border-inline-end: 1px solid var(--gnome-toolbar-border-color) !important;
+	}
 }
 
 link[href="chrome://browser/content/sidebar/sidebar-main.css"] + .wrapper {


### PR DESCRIPTION
Update from #972:

> Not sure if this is the best way to fix this problem, but this worked (tested) for me. Feel free to rewrite the logic if you prefer two media queries, etc!

> I'm going to move this into a feature branch on my repository and update to use `[positionend]` which should be better than `-moz-pref("sidebar.position_start")`.