### PR TITLE
add `sidebar.revamp.round-content-area` support

### DIFF
--- a/theme/parts/sidebar.css
+++ b/theme/parts/sidebar.css
@@ -6,14 +6,6 @@
 #sidebar-main {
 	--button-size-icon: var(--gnome-button-size) !important;
 	background-color: var(--gnome-sidebar-background) !important;
-
-	&[positionend] {
-		border-inline-start: 1px solid var(--gnome-toolbar-border-color) !important;
-	}
-
-	&:not([positionend]) {
-		border-inline-end: 1px solid var(--gnome-toolbar-border-color) !important;
-	}
 }
 
 link[href="chrome://browser/content/sidebar/sidebar-main.css"] + .wrapper {

--- a/theme/parts/tabbox.css
+++ b/theme/parts/tabbox.css
@@ -2,12 +2,6 @@
 
 @namespace xul "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
 
-@media screen and (moz-pref: "sidebar.revamp.round-content-area") {
-	.tabbrowser-tabbox {
-		border-radius: 12px;
-	}
-}
-
 /* Main tab content */
 .tabbrowser-tabbox {
 	border: 1px solid var(--gnome-border-color);

--- a/theme/parts/tabbox.css
+++ b/theme/parts/tabbox.css
@@ -1,0 +1,8 @@
+/*Tabbox*/
+
+@namespace xul "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
+
+/* Main tab content */
+.tabbrowser-tabbox {
+	border: 1px solid var(--gnome-border-color);
+}

--- a/theme/parts/tabbox.css
+++ b/theme/parts/tabbox.css
@@ -2,6 +2,12 @@
 
 @namespace xul "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
 
+@media screen and (moz-pref: "sidebar.revamp.round-content-area") {
+	.tabbrowser-tabbox {
+		border-radius: 12px;
+	}
+}
+
 /* Main tab content */
 .tabbrowser-tabbox {
 	border: 1px solid var(--gnome-border-color);

--- a/theme/parts/tabbox.css
+++ b/theme/parts/tabbox.css
@@ -4,5 +4,5 @@
 
 /* Main tab content */
 .tabbrowser-tabbox {
-	border: 1px solid var(--gnome-border-color);
+	border: 1px solid rgba(0,0,0,0.9);
 }

--- a/theme/parts/toolbox.css
+++ b/theme/parts/toolbox.css
@@ -14,7 +14,6 @@
 /* Toolbox colors */
 #navigator-toolbox {
 	background: var(--gnome-toolbar-background) !important;
-	border-bottom: 1px solid var(--gnome-toolbar-border-color) !important;
 }
 
 #PersonalToolbar, #toolbar-menubar, #TabsToolbar, findbar {


### PR DESCRIPTION
Moves the border from the toolbox and sidebar to tabbox.
Adds #947 (sorry for the multiple references, i promise this is the last)