### PR TITLE
Better group labels, dialog fix

### DIFF
--- a/theme/parts/dialogs.css
+++ b/theme/parts/dialogs.css
@@ -9,6 +9,7 @@ window {
 
 dialog {	
 	padding: var(--gnome-dialog-padding) !important;
+	color: var(--gnome-window-color);
 }
 
 /* Dialog box */

--- a/theme/parts/tabsbar.css
+++ b/theme/parts/tabsbar.css
@@ -566,6 +566,8 @@ tab-group {
 /* Tabs group label */
 .tab-group-label {
 	border-radius: 26px !important;
+	color: var(--gnome-window-color) !important;
+	margin: 0px 1px 6px !important;
 
 	tab-group[collapsed] & {
 		@media (prefers-color-scheme: dark) {
@@ -573,12 +575,12 @@ tab-group {
 		}
 	}
 
-	#tabbrowser-tabs[orient="horizontal"] &,
-	#tabbrowser-tabs[orient="vertical"][expanded] & {
-		padding: 2px 9px !important;
+	#tabbrowser-tabs[orient="horizontal"] & {
+		padding: 2px 9px 3px !important;
 	}
 
 	#tabbrowser-tabs[orient="vertical"][expanded] & {
+		padding: 2px 9px !important;
 		align-items: center !important;
 		display: flex;
 		margin-block: var(--gnome-toolbar-padding) !important;
@@ -594,9 +596,17 @@ tab-group {
 			margin-inline-end: 3px;
 			width: 16px;
 		}
+
 		tab-group:not([collapsed]) &::before {
 			background-image: var(--gnome-icon-pan-down-symbolic);
 		}
+	}
+
+	&[aria-label="Unnamed Group"] {
+		min-height: unset !important;
+		min-width: unset !important;
+		margin-top: 1px !important;
+		height: 18px;
 	}
 }
 


### PR DESCRIPTION
Firefox's group labels look pretty awful. Now they're more appealing:


![](https://github.com/user-attachments/assets/f77f058f-2ec0-4f1d-b8fe-425aa86820a3)
Colors were omitted and margins may need to be adjusted... my font scale is different so YMMV.

Also dialogs weren't using `--gnome-window-color`. btw this variable hasn't reflected my GTK theme since `v121.1` so I've been setting it to `--gnome-[toolbar|entry]-color` since.