### PR TITLE
Don't clip firefox-view-button

### DIFF
--- a/theme/parts/tabsbar.css
+++ b/theme/parts/tabsbar.css
@@ -721,6 +721,8 @@ tab-group {
 	height: 16px !important;
 	opacity: 1 !important;
 	width: 16px !important;
+	overflow: visible !important;
+	border-radius: initial !important;
 }
 :root:not([privatebrowsingmode="temporary"]):not([firefoxviewhidden]) :is(#firefox-view-button, #wrapper-firefox-view-button) + #tabbrowser-tabs {
 	border-inline-start: 0 !important;


### PR DESCRIPTION
with `gnomeTheme.noThemedIcons: true`

Before;
![image](https://github.com/user-attachments/assets/9190ee7e-7e53-482e-b5a1-da922031bf6d)

After: 
![image](https://github.com/user-attachments/assets/c9271f6f-cebb-4c37-ae40-1837bce5f6e5)