### PR TITLE
fix(menuitem): update menuitem icon colors

### DIFF
--- a/theme/parts/icons.css
+++ b/theme/parts/icons.css
@@ -248,6 +248,7 @@ button.close::before {
 	}
 	menuitem[type="checkbox"][checked="true"] {
 		list-style-image: var(--gnome-icon-select-symbolic) !important;
+		fill: white !important;
 	}
 	menuitem[type="checkbox"][disabled="true"] .menu-iconic-icon {
 		opacity: 0.5;
@@ -259,6 +260,7 @@ button.close::before {
 	}
 	menuitem[type="radio"][checked="true"] {
 		list-style-image: var(--gnome-icon-bullet-symbolic) !important;
+		fill: var(--gnome-accent-bg) !important;
 	}
 	menuitem[type="radio"] .menu-iconic-icon {
 		border-radius: 100%;


### PR DESCRIPTION
### Description

Set property for checked checkbox and radio menuitems to match the colors with html checkbox and radio inputs. Checkbox icons are now filled white, while radio icons use the accent background color.

#### Before
![изображение](https://github.com/user-attachments/assets/d9a2aa46-c5e2-4a07-a78e-bc3a4ff0cdf7)
![изображение](https://github.com/user-attachments/assets/253fdc23-7fa1-407b-a8b7-b2e2ab96c5d3)

#### After (same in dark and light modes)
![Screenshot From 2025-06-17 04-27-03](https://github.com/user-attachments/assets/58dd6436-668a-4f59-bff2-7c46a60b2e92)

#### Rendered in HTML (for comparison)
![изображение](https://github.com/user-attachments/assets/83467bf0-d748-48d6-8801-94af3613c840)
