### PR TITLE
fix(titlebar): fix search mode selector

### DIFF
--- a/theme/parts/urlbar.css
+++ b/theme/parts/urlbar.css
@@ -64,19 +64,19 @@ toolbarspring {
 		}
 	}
 }
-#searchmode-switcher-icon {
+.searchmode-switcher-icon {
 	margin-inline-start: 6px !important;
 }
-#searchmode-switcher-chicklet {
+.searchmode-switcher-chicklet {
 	background-color: var(--gnome-button-background) !important;
 	border-start-end-radius: var(--gnome-button-radius) !important;
 	border-end-end-radius: var(--gnome-button-radius) !important;
 }
-#searchmode-switcher-title {
+.searchmode-switcher-title {
 	color: var(--gnome-window-color);
 	padding-inline: 4px !important;
 }
-#searchmode-switcher-close {
+.searchmode-switcher-close {
 	background-size: 16px !important;
 	border-radius: 24px !important;
 	width: 24px !important;


### PR DESCRIPTION
for some reason selectors were using ids instead of classes and therefore weren't applying properly

before: 
![before](https://github.com/user-attachments/assets/fbace608-8958-4942-b396-d09f6dbe931e)

after:
![after](https://github.com/user-attachments/assets/ec0a5f09-3ca5-47eb-ba1d-0119c4e71ed4)