### PR TITLE
fix(buttons): fix notifications pop-up

### DIFF
--- a/theme/parts/buttons.css
+++ b/theme/parts/buttons.css
@@ -239,8 +239,9 @@ menulist,
 #context-navigation menuitem:not(:last-of-type),
 .findbar-container toolbarbutton.findbar-find-previous,
 .findbar-button:not(:last-of-type),
-.search-panel-one-offs .searchbar-engine-one-off-item:not(:last-child),
-.popup-notification-secondary-button:not([dropmarkerhidden="true"]):not(#hack) {
+.search-panel-one-offs .searchbar-engine-one-off-item:not(:last-child) {
+	border-start-end-radius: 0 !important;
+	border-end-end-radius: 0 !important;
 	border-right-width: 0 !important;
 	margin-inline-end: 0 !important;
 }
@@ -251,8 +252,7 @@ menulist,
 .findbar-container toolbarbutton.findbar-find-previous,
 .findbar-container toolbarbutton.findbar-find-next,
 .findbar-button:not(:first-of-type),
-.search-panel-one-offs .searchbar-engine-one-off-item:not(:first-child),
-.popup-notification-dropmarker:not(#hack) {
+.search-panel-one-offs .searchbar-engine-one-off-item:not(:first-child) {
 	border-end-start-radius: 0 !important;
 	border-start-start-radius: 0 !important;
 	margin-inline-start: 0 !important;


### PR DESCRIPTION
"always block" button in allow notifications pop-up has wrong border radius.

before:
<img width="934" height="284" alt="buttons_before" src="https://github.com/user-attachments/assets/9e6130af-853b-48bb-a583-1b9d1d445192" />

after:
<img width="928" height="284" alt="buttons_after" src="https://github.com/user-attachments/assets/b98bd823-84e5-43d0-997f-ef244249abae" />

